### PR TITLE
adding requirements needed in virtualenv for bootstrap

### DIFF
--- a/bootstrap_requirements.txt
+++ b/bootstrap_requirements.txt
@@ -1,0 +1,7 @@
+flake8
+mockito
+pyassert
+mock
+coverage
+pyfix
+wheel


### PR DESCRIPTION
I tracked down the dependencies required for a successful bootstrap:

```
$ mkvirtualenv pybuilder
$ pip install -r bootstrap_requirements.txt
$ ./bootstrap
```
