### PR TITLE
add trailing space after ITs finished.

### DIFF
--- a/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
@@ -300,8 +300,9 @@ class TaskPoolProgress(object):
         waiting_tasks_count = self.waiting_tasks_count
         waiting_tasks_progress = styled_text(
             self.WAITING_SYMBOL * waiting_tasks_count, fg(GREY))
+        trailing_space = ' ' if not pacman else ''
 
-        return "[%s%s%s%s]" % (finished_tests_progress, pacman, running_tests_progress, waiting_tasks_progress)
+        return "[%s%s%s%s]%s" % (finished_tests_progress, pacman, running_tests_progress, waiting_tasks_progress, trailing_space)
 
     def render_to_terminal(self):
         if self.can_be_displayed:

--- a/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
@@ -103,7 +103,7 @@ class TaskPoolProgressTests(unittest.TestCase):
         progress.update(8)
 
         self.assertEqual(progress.render(),
-                         '[--------]')
+                         '[--------] ')
 
     @patch('pybuilder.plugins.python.integrationtest_plugin.styled_text')
     @patch('pybuilder.plugins.python.integrationtest_plugin.print_text')


### PR DESCRIPTION
This is necessary to erase the last character since the render length
is reduced by one without the pacman symbol when all is said and done.
