### PR TITLE
make it possible to chain distutils commands

### DIFF
--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -164,7 +164,9 @@ def build_binary_distribution(project, logger):
     for command in commands:
         logger.debug("Executing distutils command %s", command)
         with open(os.path.join(reports_dir, command), "w") as output_file:
-            process = subprocess.Popen((sys.executable, setup_script, command),
+            commands = [sys.executable, setup_script]
+            commands.extend(command.split())
+            process = subprocess.Popen(commands,
                                        cwd=project.expand_path("$dir_dist"),
                                        stdout=output_file,
                                        stderr=output_file,


### PR DESCRIPTION
This is required for upload, which will only work if a sdist was created
in the same "transaction" (e.G. command chaining)
