### PR TITLE
Fix autoversioning for older git version like found on RHEL6

### DIFF
--- a/src/main/python/pybuilder/vcs.py
+++ b/src/main/python/pybuilder/vcs.py
@@ -45,17 +45,20 @@ class VCSRevision(object):
             "Cannot determine VCS revision: project is neither a git nor a svn repo.")
 
     def get_git_revision_count(self):
+        # NOTE: git rev-list HEAD --count does not work on RHEL6, hence we count ourselves.
         exit_code, stdout, stderr = execute_command_and_capture_output(
-            "git", "rev-list", "HEAD", "--count")
+            "git", "rev-list", "HEAD")
         if exit_code != 0:
-            raise PyBuilderException("Cannot determine git revision: git rev-list HEAD failed.")
-        return stdout.strip()
+            raise PyBuilderException("Cannot determine git revision: git rev-list HEAD failed:\n{0}".
+                                     format(stderr))
+        return str(len(stdout.splitlines()))
 
     def get_svn_revision_count(self):
         exit_code, stdout, stderr = execute_command_and_capture_output(
             "svnversion")
         if exit_code != 0 or "Unversioned directory" in stdout or "Uncommitted" in stdout:
-            raise PyBuilderException("Cannot determine svn revision: svnversion failed or unversioned directory.")
+            raise PyBuilderException("Cannot determine svn revision: svnversion failed or unversioned directory:\n{0}".
+                                     format(stderr))
         return stdout.strip().replace("M", "").replace("S", "").replace("P", "").split(":")[0]
 
     def is_a_git_repo(self):

--- a/src/unittest/python/vcs_tests.py
+++ b/src/unittest/python/vcs_tests.py
@@ -73,12 +73,8 @@ class VCSRevisionTest(unittest.TestCase):
         self.assertEquals("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_when_git_revlist_succeeds(self):
-        self.execute_command.return_value = 0, "451", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_git_revision_count())
-
-    def test_should_return_revision_without_trailing_emptiness_when_git_revlist_succeeds(self):
-        self.execute_command.return_value = 0, "451  \n", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_git_revision_count())
+        self.execute_command.return_value = 0, "1\n2\n3", "any-stderr"
+        self.assertEquals("3", VCSRevision().get_git_revision_count())
 
     def test_should_detect_svn_when_status_succeeds(self):
         self.execute_command.return_value = 0, "", ""


### PR DESCRIPTION
The --count option was not supported, counting internally now.

I also added error output in case git or subversion did not work as expected.