### PR TITLE
Pycharm test dirs

### DIFF
--- a/src/main/python/pybuilder/plugins/python/pycharm_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/pycharm_plugin.py
@@ -28,6 +28,8 @@ PROJECT_TEMPLATE = string.Template("""<?xml version="1.0" encoding="UTF-8"?>
   <component name="NewModuleRootManager">
     <content url="file://$$MODULE_DIR$$">
       <sourceFolder url="file://$$MODULE_DIR$$/${source_dir}" isTestSource="false" />
+      <sourceFolder url="file://$$MODULE_DIR$$/${unittest_source_dir}" isTestSource="true" />
+      <sourceFolder url="file://$$MODULE_DIR$$/${integrationtest_source_dir}" isTestSource="true" />
       <excludeFolder url="file://$$MODULE_DIR$$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -62,7 +64,9 @@ def pycharm_generate(project, logger):
     _ensure_directory_present(pycharm_directory)
 
     project_metadata = PROJECT_TEMPLATE.substitute({
-        "source_dir": project.get_property("dir_source_main_python")
+        "source_dir": project.get_property("dir_source_main_python"),
+        "unittest_source_dir": project.get_property("dir_source_unittest_python"),
+        "integrationtest_source_dir": project.get_property("dir_source_integrationtest_python")
     })
 
     project_file_path = os.path.join(pycharm_directory, project_file_name)

--- a/src/main/python/pybuilder/plugins/python/pycharm_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/pycharm_plugin.py
@@ -27,9 +27,7 @@ PROJECT_TEMPLATE = string.Template("""<?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$$MODULE_DIR$$">
-      <sourceFolder url="file://$$MODULE_DIR$$/${source_dir}" isTestSource="false" />
-      <sourceFolder url="file://$$MODULE_DIR$$/${unittest_source_dir}" isTestSource="true" />
-      <sourceFolder url="file://$$MODULE_DIR$$/${integrationtest_source_dir}" isTestSource="true" />
+      <sourceFolder url="file://$$MODULE_DIR$$/${source_dir}" isTestSource="false" />${unit_tests}${integration_tests}
       <excludeFolder url="file://$$MODULE_DIR$$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -62,11 +60,19 @@ def pycharm_generate(project, logger):
     project_file_name = "{0}.iml".format(project.name)
 
     _ensure_directory_present(pycharm_directory)
+    unit_tests = ""
+    integration_tests = ""
+    if project.get_property("dir_source_unittest_python"):
+        unit_tests = """\n      <sourceFolder url="file://$MODULE_DIR$/""" + project.get_property(
+            "dir_source_unittest_python") + """" isTestSource="true" />"""
+    if project.get_property("dir_source_integrationtest_python"):
+        integration_tests = """\n      <sourceFolder url="file://$MODULE_DIR$/""" + project.get_property(
+            "dir_source_integrationtest_python") + """" isTestSource="true" />"""
 
     project_metadata = PROJECT_TEMPLATE.substitute({
         "source_dir": project.get_property("dir_source_main_python"),
-        "unittest_source_dir": project.get_property("dir_source_unittest_python"),
-        "integrationtest_source_dir": project.get_property("dir_source_integrationtest_python")
+        "unit_tests": unit_tests,
+        "integration_tests": integration_tests
     })
 
     project_file_path = os.path.join(pycharm_directory, project_file_name)

--- a/src/unittest/python/plugins/python/pycharm_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pycharm_plugin_tests.py
@@ -55,6 +55,8 @@ class PycharmPluginTests(unittest.TestCase):
     def test_should_write_pycharm_file(self, os, mock_open):
         project = Project('basedir', name='pybuilder')
         project.set_property('dir_source_main_python', 'src/main/python')
+        project.set_property('dir_source_unittest_python', 'src/unittest/python')
+        project.set_property('dir_source_integrationtest_python', 'src/integrationtest/python')
         mock_open.return_value = MagicMock(spec=TYPE_FILE)
         os.path.join.side_effect = lambda first, second: first + '/' + second
 
@@ -69,6 +71,8 @@ class PycharmPluginTests(unittest.TestCase):
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/python" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/unittest/python" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/integrationtest/python" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION
Generate entries for unit and integration test directories (if respective plugins are activated) and mark them as test sources