### PR TITLE
Fixes issues #150, #151, #156 and #160

### DIFF
--- a/build.py
+++ b/build.py
@@ -88,6 +88,8 @@ def initialize(project):
     if sys.version_info[0:2] == (2, 6):
         project.build_depends_on("importlib")  # for fluentmock
 
+    project.depends_on("tblib")
+
     project.set_property("verbose", True)
 
     project.set_property("coverage_break_build", False)

--- a/src/main/python/pybuilder/__init__.py
+++ b/src/main/python/pybuilder/__init__.py
@@ -20,14 +20,6 @@ from pybuilder.errors import BuildFailedException
 
 __version__ = "${version}"
 
-try:
-    import tblib.pickling_support
-
-    tblib.pickling_support.install()
-except ImportError:
-    # This will happen if we have not yet installed dependencies
-    pass
-
 
 def bootstrap():
     import sys

--- a/src/main/python/pybuilder/errors.py
+++ b/src/main/python/pybuilder/errors.py
@@ -23,8 +23,8 @@
 
 
 class PyBuilderException(Exception):
-
     def __init__(self, message, *arguments):
+        super(PyBuilderException, self).__init__(message, *arguments)
         self._message = message
         self._arguments = arguments
 
@@ -37,13 +37,11 @@ class PyBuilderException(Exception):
 
 
 class InvalidNameException(PyBuilderException):
-
     def __init__(self, name):
         super(InvalidNameException, self).__init__("Invalid name: %s", name)
 
 
 class NoSuchTaskException(PyBuilderException):
-
     def __init__(self, name):
         super(NoSuchTaskException, self).__init__("No such task %s", name)
 
@@ -56,12 +54,14 @@ class CircularTaskDependencyException(PyBuilderException):
                 CircularTaskDependencyException, self).__init__("Circular task dependency detected between %s and %s",
                                                                 first,
                                                                 second)
+        else:
+            super(CircularTaskDependencyException, self).__init__(first)
+
         self.first = first
         self.second = second
 
 
 class MissingPrerequisiteException(PyBuilderException):
-
     def __init__(self, prerequisite, caller="n/a"):
         super(
             MissingPrerequisiteException, self).__init__("Missing prerequisite %s required by %s",
@@ -69,7 +69,6 @@ class MissingPrerequisiteException(PyBuilderException):
 
 
 class MissingTaskDependencyException(PyBuilderException):
-
     def __init__(self, source, dependency):
         super(
             MissingTaskDependencyException, self).__init__("Missing task '%s' required for task '%s'",
@@ -77,7 +76,6 @@ class MissingTaskDependencyException(PyBuilderException):
 
 
 class MissingActionDependencyException(PyBuilderException):
-
     def __init__(self, source, dependency):
         super(
             MissingActionDependencyException, self).__init__("Missing task '%s' required for action '%s'",
@@ -85,7 +83,6 @@ class MissingActionDependencyException(PyBuilderException):
 
 
 class MissingPluginException(PyBuilderException):
-
     def __init__(self, plugin, message=""):
         super(MissingPluginException, self).__init__(
             "Missing plugin '%s': %s", plugin, message)
@@ -96,14 +93,12 @@ class BuildFailedException(PyBuilderException):
 
 
 class MissingPropertyException(PyBuilderException):
-
     def __init__(self, property):
         super(MissingPropertyException, self).__init__(
             "No such property: %s", property)
 
 
 class ProjectValidationFailedException(BuildFailedException):
-
     def __init__(self, validation_messages):
         BuildFailedException.__init__(
             self, "Project validation failed: " + "\n-".join(validation_messages))

--- a/src/main/python/pybuilder/errors.py
+++ b/src/main/python/pybuilder/errors.py
@@ -47,18 +47,14 @@ class NoSuchTaskException(PyBuilderException):
 
 
 class CircularTaskDependencyException(PyBuilderException):
-
-    def __init__(self, first, second=None):
-        if second:
-            super(
-                CircularTaskDependencyException, self).__init__("Circular task dependency detected between %s and %s",
-                                                                first,
-                                                                second)
-        else:
-            super(CircularTaskDependencyException, self).__init__(first)
-
-        self.first = first
-        self.second = second
+    def __init__(self, first, second=None, message=None):
+        if message:
+            super(CircularTaskDependencyException, self).__init__(message)
+        elif second:
+            super(CircularTaskDependencyException, self).__init__("Circular task dependency detected between %s and %s",
+                                                                  first, second)
+            self.first = first
+            self.second = second
 
 
 class MissingPrerequisiteException(PyBuilderException):

--- a/src/main/python/pybuilder/excp_util_2.py
+++ b/src/main/python/pybuilder/excp_util_2.py
@@ -16,30 +16,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from pybuilder.errors import BuildFailedException
+"""
+    The PyBuilder exception utils module for Python version 2.x
+"""
 
-__version__ = "${version}"
+# flake8: noqa
 
-try:
-    import tblib.pickling_support
-
-    tblib.pickling_support.install()
-except ImportError:
-    # This will happen if we have not yet installed dependencies
-    pass
-
-
-def bootstrap():
-    import sys
-    import inspect
-
-    try:
-        current_frame = inspect.currentframe()
-        previous_frame = current_frame.f_back
-        name_of_previous_frame = previous_frame.f_globals['__name__']
-        if name_of_previous_frame == '__main__':
-            import pybuilder.cli
-
-            sys.exit(pybuilder.cli.main(*sys.argv[1:]))
-    except BuildFailedException:
-        sys.exit(1)
+def raise_exception(ex, tb):
+    raise ex, None, tb

--- a/src/main/python/pybuilder/excp_util_3.py
+++ b/src/main/python/pybuilder/excp_util_3.py
@@ -16,30 +16,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from pybuilder.errors import BuildFailedException
+"""
+    The PyBuilder exception utils module for Python version 3.x
+"""
 
-__version__ = "${version}"
+# flake8: noqa
 
-try:
-    import tblib.pickling_support
-
-    tblib.pickling_support.install()
-except ImportError:
-    # This will happen if we have not yet installed dependencies
-    pass
-
-
-def bootstrap():
-    import sys
-    import inspect
-
-    try:
-        current_frame = inspect.currentframe()
-        previous_frame = current_frame.f_back
-        name_of_previous_frame = previous_frame.f_globals['__name__']
-        if name_of_previous_frame == '__main__':
-            import pybuilder.cli
-
-            sys.exit(pybuilder.cli.main(*sys.argv[1:]))
-    except BuildFailedException:
-        sys.exit(1)
+def raise_exception(ex, tb):
+    raise ex.with_traceback(tb)

--- a/src/main/python/pybuilder/plugins/python/coverage_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/coverage_plugin.py
@@ -84,9 +84,7 @@ def do_coverage(project, logger, reactor, execution_prefix, execution_name, targ
         logger.debug("Module '%s' coverage to be verified", module_name)
 
     _delete_non_essential_modules()
-
-    # Reimport self
-    __import__("pybuilder.plugins.python")
+    __import__("pybuilder.plugins.python")  # Reimport self
 
     # Starting fresh
     from coverage import coverage as coverage_factory
@@ -126,7 +124,7 @@ def do_coverage(project, logger, reactor, execution_prefix, execution_name, targ
             try:
                 module = __import__(module_name)
             except SyntaxError as e:
-                logger.warn("Coverage for module '%s' cannot be established - the module doesn't compile: %s",
+                logger.warn("Coverage for module '%s' cannot be established - syntax error: %s",
                             module_name, e)
                 continue
 
@@ -250,6 +248,7 @@ def _is_module_essential(module_name, sys_packages, sys_modules):
 
     # Essential since we're in a fork for communicating exceptions back
     sys_packages.append("tblib")
+    sys_packages.append("pybuilder.errors")
 
     for package in sys_packages:
         if module_name == package or module_name.startswith(package + "."):

--- a/src/main/python/pybuilder/plugins/python/coverage_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/coverage_plugin.py
@@ -277,7 +277,7 @@ def _get_system_assets():
             if nm == "__init__.py":
                 init_file = os.path.join(top, nm)
                 package_dirs.append(init_file[:-len("__init__.py") - len(os.sep)])
-            elif nm[-3:] in (".so", ".py") or nm[-4:] in (".pyd", ".dll"):
+            elif nm[-3:] in (".so", ".py") or nm[-4:] in (".pyd", ".dll", ".pyw") or nm[-2:] == ".o":
                 module_file = os.path.join(top, nm)
                 module_files.append(module_file)
 
@@ -296,7 +296,11 @@ def _get_system_assets():
         module_dir = os.path.dirname(module_file)
         for sys_path_dir in canon_sys_path:
             if module_dir == sys_path_dir:
-                modules.append(os.path.basename(module_file).split(".")[0])
+                module_name_parts = os.path.basename(module_file).split(".")
+                module_name = module_name_parts[0]
+                if module_name_parts[1] in ("so", "dll", "o") and module_name_parts[0].endswith("module"):
+                    module_name = module_name[:-6]
+                modules.append(module_name)
                 break
 
     return packages, modules

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -258,6 +258,14 @@ def fork_process(group=None, target=None, name=None, args=(), kwargs={}):
     If a target raises an exception, the exception is re-raised in the parent process
     @return tuple consisting of process exit code and target's return value
     """
+    from sys import modules
+
+    try:
+        modules["tblib.pickling_support"]
+    except KeyError:
+        import tblib.pickling_support
+
+        tblib.pickling_support.install()
 
     q = multiprocessing.Queue()
 

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -30,8 +30,14 @@ import subprocess
 import tempfile
 import time
 from subprocess import Popen, PIPE
+import multiprocessing
 
 from pybuilder.errors import MissingPrerequisiteException, PyBuilderException
+
+if sys.version_info[0] < 3:  # if major is less than 3
+    from .excp_util_2 import raise_exception
+else:
+    from .excp_util_3 import raise_exception
 
 
 def get_all_dependencies_for_task(task):
@@ -40,6 +46,7 @@ def get_all_dependencies_for_task(task):
     task function (but not the given task itself)
     """
     from pybuilder.reactor import Reactor
+
     task_name = task.__name__
     execution_manager = Reactor.current_instance().execution_manager
     task_and_all_dependencies = execution_manager.collect_all_transitive_tasks([task_name])
@@ -55,7 +62,7 @@ def format_timestamp(timestamp):
 
 
 def timedelta_in_millis(timedelta):
-    return((timedelta.days * 24 * 60 * 60) + timedelta.seconds) * 1000 + round(timedelta.microseconds / 1000)
+    return ((timedelta.days * 24 * 60 * 60) + timedelta.seconds) * 1000 + round(timedelta.microseconds / 1000)
 
 
 def as_list(*whatever):
@@ -185,7 +192,6 @@ def write_file(file_name, *lines):
 
 
 class Timer(object):
-
     @staticmethod
     def start():
         return Timer()
@@ -220,7 +226,6 @@ def apply_on_files(start_directory, closure, globs, *additional_closure_argument
 
 
 class GlobExpression(object):
-
     def __init__(self, expression):
         self.expression = expression
         self.regex = "^" + expression.replace("**", ".+").replace("*", "[^/]*") + "$"
@@ -245,3 +250,33 @@ def mkdir(directory):
             raise PyBuilderException(message, directory)
         return
     os.makedirs(directory)
+
+
+def fork_process(group=None, target=None, name=None, args=(), kwargs={}):
+    """
+    Forks a child, making sure that all exceptions from the child are safely sent to the parent
+    If a target raises an exception, the exception is re-raised in the parent process
+    @return tuple consisting of process exit code and target's return value
+    """
+
+    q = multiprocessing.Queue()
+
+    def instrumented_target(*args, **kwargs):
+        try:
+            q.put((target(*args, **kwargs), None, None))
+        except:
+            _, ex, tb = sys.exc_info()
+            q.put((None, ex, tb))
+        finally:
+            q.close()
+            q.join_thread()
+
+    p = multiprocessing.Process(group=group, target=instrumented_target, name=name, args=args, kwargs=kwargs)
+    p.start()
+    result = q.get()
+    q.close()
+    q.join_thread()
+    p.join()
+    if result[1]:
+        raise_exception(result[1], result[2])
+    return p.exitcode, result[0]


### PR DESCRIPTION
Forking option in coverage and unittest is now deprecated (removed in unittest since never made public)
Coverage will always fork
Unittest will always fork unless is already forked in coverage
utils.fork_process is now used in both to capture exit code, returned value and possible exception (with traceback) from a forked process
Module reloading is removed since it doesn't ever work when modules keep state and rely on intermodule dependencies
This should be a problem since coverage and unittests run in different forks and will reinitialize the modules anyway

Closes pybuilder/pybuilder#150, closes pybuilder/pybuilder#151