### PR TITLE
New plugin stdeb

### DIFF
--- a/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
@@ -1,0 +1,67 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2015 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from pybuilder.utils import assert_can_execute
+from pybuilder.core import (after,
+                            task,
+                            init,
+                            use_plugin,
+                            depends)
+
+__author__ = 'Marcel Wolf'
+
+use_plugin("core")
+
+
+@init
+def initialize_make_deb_plugin(project):
+
+    project.build_depends_on("stdeb")
+    project.build_depends_on("subprocess32")
+
+
+@after("prepare")
+def assert_py2dsc_deb_is_available(logger):
+    """Asserts that the py2dsc-deb is available.
+    """
+    logger.debug("Checking if py2dsc-deb is available.")
+
+    assert_can_execute(
+        ["py2dsc-deb", "-h"], "py2dsc-deb", "plugin python.py2dsc_deb")
+
+
+@task("py2dsc_prepare", "prepare for buiding a debian package")
+@depends("publish")
+def prepare():
+    pass
+
+
+@task("py2dsc_deb", "convert a source tarball into a Debian source package and build a .deb package")
+@depends("py2dsc_prepare")
+def py2dsc_deb(project, logger):
+    """Runs py2dsc-deb against the setup.py for the given project.
+    """
+    import subprocess32 as subprocess
+    logger.info("converting to deb package")
+    package_name = project.name + "-" + project.version + ".tar.gz"
+    path_to_source_tarball = project.expand_path(
+        "$dir_dist/dist/" + package_name)
+    path_final_build = project.expand_path("$dir_dist/dist/")
+
+    subprocess.call(["py2dsc-deb", "-d", path_final_build, path_to_source_tarball])

--- a/src/unittest/python/plugins/python/stdeb_plugin_tests.py
+++ b/src/unittest/python/plugins/python/stdeb_plugin_tests.py
@@ -1,0 +1,68 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2015 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from unittest import TestCase
+from mock import Mock, patch
+from pybuilder.core import Project
+from logging import Logger
+from pybuilder.plugins.python.stdeb_plugin import (
+    assert_py2dsc_deb_is_available,
+    get_py2dsc_deb_command,
+    assert_dpkg_is_available)
+
+
+class CheckStdebAvailableTests(TestCase):
+
+    @patch('pybuilder.plugins.python.stdeb_plugin.assert_can_execute')
+    def test_should_check_that_py2dsc_deb_can_be_executed(self, mock_assert_can_execute):
+
+        mock_logger = Mock(Logger)
+
+        assert_py2dsc_deb_is_available(mock_logger)
+
+        expected_command_line = ['py2dsc-deb', '-h']
+        mock_assert_can_execute.assert_called_with(
+            expected_command_line, 'py2dsc-deb', 'plugin python.stdeb')
+
+    @patch('pybuilder.plugins.python.stdeb_plugin.assert_can_execute')
+    def test_should_check_that_dpkg_buildpackage_can_be_executed(self, mock_assert_can_execute):
+
+        mock_logger = Mock(Logger)
+
+        assert_dpkg_is_available(mock_logger)
+
+        expected_command_line = ['dpkg-buildpackage', '--help']
+        mock_assert_can_execute.assert_called_with(
+            expected_command_line, 'dpkg-buildpackage', 'plugin python.stdeb')
+
+
+class StdebBuildCommandTests(TestCase):
+
+    def setUp(self):
+        self.project = Project("basedir")
+
+    def test_should_generate_stdeb_build_command_with_project_properties(self):
+        self.project.set_property(
+            "deb_package_maintainer", "foo <foo@bar.com>")
+        self.project.set_property("path_final_build", "/path/to/final/build")
+        self.project.set_property("path_to_source_tarball", "/path/to/source/")
+
+        py2dsc_deb_command = get_py2dsc_deb_command(self.project)
+
+        self.assertEqual(
+            py2dsc_deb_command, "py2dsc-deb --maintainer 'foo <foo@bar.com>' -d '/path/to/final/build' /path/to/source/")


### PR DESCRIPTION
Hi,

i’ve wrote a new pybuilder plugin, with this plugin it's now possible to build debian packages of you pybuilder based project.

the stdeb plugin (```use_plugin("python.stdeb”)```) provides a new task called ```make_deb``` and some new properties:
```deb_package_maintainer```, ```path_final_build```, ```path_to_source_tarball```

you can overwrite the default values in your build.py 

To use the plugin you need an debian based operating system (tested on debian 8 and ubuntu 15.04) with the following packages installed:

- dpkg-dev
- python-setuptools, python-all, debhelper

We can’t resolv this requirements with pybuilder tools, because we can’t check for installed os packages. i've used ```assert_can_execute```to check for the most but not every packages provides executables
If you like to discuss the opportunity to check for os packages i will create an enhancement issue for that - i have some ideas.

i’ve checked the debian package of pybuilder with lintian and all issues are project related and can be solved:

```
- W: python-pybuilder: new-package-should-close-itp-bug  # no changelog
- E: python-pybuilder: no-copyright-file
- W: python-pybuilder: description-synopsis-starts-with-article
- W: python-pybuilder: extended-description-line-too-long
- W: python-pybuilder: extended-description-line-too-long
- W: python-pybuilder: extended-description-line-too-long
- W: python-pybuilder: binary-without-manpage usr/bin/pyb
- W: python-pybuilder: binary-without-manpage usr/bin/pyb_
```


if you like i can provode a verbose version of this output.

 looking forward to your feedback

