### PR TITLE
Don't fork on windows

### DIFF
--- a/src/main/python/pybuilder/plugins/python/coverage_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/coverage_plugin.py
@@ -27,7 +27,7 @@ import os
 from distutils import sysconfig
 
 from pybuilder.core import init, after, use_plugin
-from pybuilder.utils import discover_modules, render_report, fork_process
+from pybuilder.utils import discover_modules, render_report, fork_process, is_windows
 from pybuilder.errors import BuildFailedException
 
 use_plugin("python.core")
@@ -71,7 +71,8 @@ def run_coverage(project, logger, reactor, execution_prefix, execution_name, tar
                     execution_prefix)
 
     logger.debug("Forking process to do %s analysis", execution_name)
-    exit_code, _ = fork_process(target=do_coverage,
+    exit_code, _ = fork_process(logger,
+                                target=do_coverage,
                                 args=(
                                     project, logger, reactor, execution_prefix, execution_name,
                                     target_task, shortest_plan))
@@ -92,8 +93,9 @@ def do_coverage(project, logger, reactor, execution_prefix, execution_name, targ
     for module_name in module_names:
         logger.debug("Module '%s' coverage to be verified", module_name)
 
-    _delete_non_essential_modules()
-    __import__("pybuilder.plugins.python")  # Reimport self
+    if not is_windows():
+        _delete_non_essential_modules()
+        __import__("pybuilder.plugins.python")  # Reimport self
 
     # Starting fresh
     from coverage import coverage as coverage_factory

--- a/src/main/python/pybuilder/plugins/python/unittest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/unittest_plugin.py
@@ -60,7 +60,8 @@ def run_tests(project, logger, execution_prefix, execution_name):
     logger.info("Running %s", execution_name)
     if not project.get_property('__running_coverage'):
         logger.debug("Forking process to run %s", execution_name)
-        exit_code, _ = fork_process(target=do_run_tests,
+        exit_code, _ = fork_process(logger,
+                                    target=do_run_tests,
                                     args=(
                                         project, logger, execution_prefix, execution_name))
         if exit_code:

--- a/src/unittest/python/utils_tests.py
+++ b/src/unittest/python/utils_tests.py
@@ -26,7 +26,7 @@ import shutil
 import sys
 from json import loads
 
-from mockito import when, verify, unstub, any
+from mockito import when, verify, unstub, any, mock
 
 import pybuilder.utils
 from pybuilder.utils import (GlobExpression,
@@ -353,7 +353,7 @@ class ForkTest(unittest.TestCase):
         def test_func():
             return "success"
 
-        val = fork_process(target=test_func)
+        val = fork_process(mock(), target=test_func)
 
         self.assertEquals(len(val), 2)
         self.assertEquals(val[0], 0)
@@ -363,12 +363,12 @@ class ForkTest(unittest.TestCase):
         def test_func(foo, bar):
             return "%s%s" % (foo, bar)
 
-        val = fork_process(target=test_func, kwargs={"foo": "foo", "bar": 10})
+        val = fork_process(mock(), target=test_func, kwargs={"foo": "foo", "bar": 10})
         self.assertEquals(len(val), 2)
         self.assertEquals(val[0], 0)
         self.assertEquals(val[1], "foo10")
 
-        val = fork_process(target=test_func, args=("foo", 20))
+        val = fork_process(mock(), target=test_func, args=("foo", 20))
         self.assertEquals(len(val), 2)
         self.assertEquals(val[0], 0)
         self.assertEquals(val[1], "foo20")
@@ -378,7 +378,7 @@ class ForkTest(unittest.TestCase):
             raise PyBuilderException("Test failure message")
 
         try:
-            val = fork_process(target=test_func)
+            val = fork_process(mock(), target=test_func)
             self.fail("should not have reached here, returned %s" % val)
         except:
             ex_type, ex, tb = sys.exc_info()
@@ -395,7 +395,7 @@ class ForkTest(unittest.TestCase):
             return FooError()
 
         try:
-            fork_process(target=test_func)
+            fork_process(mock(), target=test_func)
             self.fail("should not have reached here")
         except:
             ex_type, ex, tb = sys.exc_info()
@@ -413,7 +413,7 @@ class ForkTest(unittest.TestCase):
             raise FooError()
 
         try:
-            val = fork_process(target=test_func)
+            val = fork_process(mock(), target=test_func)
             self.fail("should not have reached here, returned %s" % val)
         except:
             ex_type, ex, tb = sys.exc_info()
@@ -436,7 +436,7 @@ class ForkTest(unittest.TestCase):
             raise FooError(Foo.bar)
 
         try:
-            val = fork_process(target=test_func)
+            val = fork_process(mock(), target=test_func)
             self.fail("should not have reached here, returned %s" % val)
         except:
             ex_type, ex, tb = sys.exc_info()


### PR DESCRIPTION
As per #184, forking support is so bad (the runtime needs to pickle
**everything**) that it's preferable to trade off some reliability
(this might falsify coverage statistics) so that windows users can
still build projects. On linux/OSX nothing changed, and coverage should
still be as accurate as possible.