### PR TITLE
extend and test the task decorator

### DIFF
--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -109,12 +109,21 @@ def task(callable_or_string=None, description=None):
         return set_name_and_task_attribute
     else:
         if not description:
-            setattr(callable_or_string, TASK_ATTRIBUTE, True)
-            return callable_or_string
+            if callable_or_string is not None:
+                setattr(callable_or_string, TASK_ATTRIBUTE, True)
+                setattr(callable_or_string, NAME_ATTRIBUTE, callable_or_string.func_name)
+                return callable_or_string
+            else:
+                def set_task_and_description_attribute(callable):
+                    setattr(callable, TASK_ATTRIBUTE, True)
+                    setattr(callable, NAME_ATTRIBUTE, callable.func_name)
+                    return callable
+
+                return set_task_and_description_attribute
         else:
             def set_task_and_description_attribute(callable):
                 setattr(callable, TASK_ATTRIBUTE, True)
-                setattr(callable, NAME_ATTRIBUTE, callable_or_string)
+                setattr(callable, NAME_ATTRIBUTE, callable.func_name)
                 setattr(callable, DESCRIPTION_ATTRIBUTE, description)
                 return callable
 

--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -111,19 +111,19 @@ def task(callable_or_string=None, description=None):
         if not description:
             if callable_or_string is not None:
                 setattr(callable_or_string, TASK_ATTRIBUTE, True)
-                setattr(callable_or_string, NAME_ATTRIBUTE, callable_or_string.func_name)
+                setattr(callable_or_string, NAME_ATTRIBUTE, callable_or_string.__name__)
                 return callable_or_string
             else:
                 def set_task_and_description_attribute(callable):
                     setattr(callable, TASK_ATTRIBUTE, True)
-                    setattr(callable, NAME_ATTRIBUTE, callable.func_name)
+                    setattr(callable, NAME_ATTRIBUTE, callable.__name__)
                     return callable
 
                 return set_task_and_description_attribute
         else:
             def set_task_and_description_attribute(callable):
                 setattr(callable, TASK_ATTRIBUTE, True)
-                setattr(callable, NAME_ATTRIBUTE, callable.func_name)
+                setattr(callable, NAME_ATTRIBUTE, callable.__name__)
                 setattr(callable, DESCRIPTION_ATTRIBUTE, description)
                 return callable
 

--- a/src/unittest/python/core_tests.py
+++ b/src/unittest/python/core_tests.py
@@ -490,6 +490,24 @@ class InitTest(unittest.TestCase):
 
 class TaskTests(unittest.TestCase):
 
+    def test_should_name_task_when_no_description_is_used(self):
+        @task
+        def task_without_description():
+            pass
+
+        self.assertEqual(task_without_description._python_builder_task, True)
+        self.assertEqual(task_without_description._python_builder_name,
+                         "task_without_description")
+
+    def test_should_name_task_when_decorator_called_with_nothing(self):
+        @task()
+        def another_task_without_description():
+            pass
+
+        self.assertEqual(another_task_without_description._python_builder_task, True)
+        self.assertEqual(another_task_without_description._python_builder_name,
+                         "another_task_without_description")
+
     def test_should_describe_task_when_description_decorator_is_used(self):
         @task
         @description("any-description")
@@ -524,6 +542,7 @@ class TaskTests(unittest.TestCase):
             pass
 
         self.assertEqual(task_with_description._python_builder_task, True)
+        self.assertEqual(task_with_description._python_builder_name, "task_with_description")
         self.assertEqual(task_with_description._python_builder_description, "any-description")
 
 


### PR DESCRIPTION
We encountred a problem when using the task decorator in the form:

```
@task(description='spam')
def ham():
    pass
```

In this case, the name of the task is ommitted and pybuilder cannot cope with
such a task.

The error message in such a case is:

```
PyBuilder version 0.11.2
Build started at 2015-11-04 14:58:23
------------------------------------------------------------
------------------------------------------------------------
BUILD FAILED - expected string or buffer
------------------------------------------------------------
Build finished at 2015-11-04 14:58:23
Build took 0 seconds (104 ms)
```

Please have a look at the solution and perhaps suggest an alterntive. (Yes, I
agree the code is a mindf**k right now) Albeight the tests are actually fairly
readable.