### PR TITLE
add appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# language: python
+# python:
+# - '2.6'
+# - '2.7'
+# - '3.3'
+# - '3.4'
+# - pypy
+
+branches:
+  only:
+  - master
+  - doc/sphinxdoc
+
+shallow_clone: true
+
+clone_depth: 1
+
+install:
+- C:\Python35\python.exe -m venv venv
+- ps: .\venv\Scripts\Activate.ps1
+- python.exe ./build.py install_dependencies -v
+
+build: false
+
+test_script:
+- python.exe ./build.py -v -X analyze install
+
+# on_success:
+# - coveralls --verbose


### PR DESCRIPTION
I got pybuilder to run on Appveyor CI for Windows with a basic appveyor.yml.

Currently it only tests against Python 35 and I think there are still some glitches with installing all deps, but maybe you are interested. Someone has to add the Appveyor integration here.