### PR TITLE
Using `-o/--exclude-all-optional` should exclude all optional tasks

### DIFF
--- a/src/cmdlinetest/test_help.t
+++ b/src/cmdlinetest/test_help.t
@@ -41,6 +41,8 @@ Usage:
                           Set/ override a property value
       -x <task>, --exclude=<task>
                           Exclude optional task dependencies
+      -o, --exclude-all-optional
+                          Exclude all optional task dependencies
       --force-exclude=<task>
                           Exclude any task dependencies (dangerous, may break
                           the build in unexpected ways)

--- a/src/main/python/pybuilder/cli.py
+++ b/src/main/python/pybuilder/cli.py
@@ -137,6 +137,12 @@ def parse_options(args):
                              metavar="<task>",
                              help="Exclude optional task dependencies")
 
+    project_group.add_option("-o", "--exclude-all-optional",
+                             action="store_true",
+                             dest="exclude_all_optional",
+                             default=False,
+                             help="Exclude all optional task dependencies")
+
     project_group.add_option("--force-exclude",
                              action="append",
                              dest="exclude_tasks",
@@ -343,7 +349,8 @@ def main(*args):
             reactor.prepare_build(property_overrides=options.property_overrides,
                                   project_directory=options.project_directory,
                                   exclude_optional_tasks=options.exclude_optional_tasks,
-                                  exclude_tasks=options.exclude_tasks
+                                  exclude_tasks=options.exclude_tasks,
+                                  exclude_all_optional=options.exclude_all_optional
                                   )
             if options.list_tasks:
                 print_list_of_tasks(reactor, quiet=options.very_quiet)
@@ -367,11 +374,12 @@ def main(*args):
 
     try:
         try:
-            reactor.prepare_build(
-                property_overrides=options.property_overrides,
-                project_directory=options.project_directory,
-                exclude_optional_tasks=options.exclude_optional_tasks,
-                exclude_tasks=options.exclude_tasks)
+            reactor.prepare_build(property_overrides=options.property_overrides,
+                                  project_directory=options.project_directory,
+                                  exclude_optional_tasks=options.exclude_optional_tasks,
+                                  exclude_tasks=options.exclude_tasks,
+                                  exclude_all_optional=options.exclude_all_optional
+                                  )
 
             if options.verbose or options.debug:
                 logger.debug("Verbose output enabled.\n")

--- a/src/main/python/pybuilder/execution.py
+++ b/src/main/python/pybuilder/execution.py
@@ -175,6 +175,7 @@ class ExecutionManager(object):
 
         self._exclude_optional_tasks = []
         self._exclude_tasks = []
+        self._exclude_all_optional = False
 
     @property
     def initializers(self):
@@ -375,9 +376,10 @@ class ExecutionManager(object):
 
         execution_plan.append(task)
 
-    def resolve_dependencies(self, exclude_optional_tasks=None, exclude_tasks=None):
+    def resolve_dependencies(self, exclude_optional_tasks=None, exclude_tasks=None, exclude_all_optional=False):
         self._exclude_optional_tasks = as_task_name_list(exclude_optional_tasks or [])
         self._exclude_tasks = as_task_name_list(exclude_tasks or [])
+        self._exclude_all_optional = exclude_all_optional
 
         for task in self._tasks.values():
             self._execute_before[task.name] = []
@@ -421,4 +423,4 @@ class ExecutionManager(object):
         return task in self._exclude_tasks
 
     def is_optional_task_excluded(self, task):
-        return task in self._exclude_optional_tasks
+        return self._exclude_all_optional or task in self._exclude_optional_tasks

--- a/src/main/python/pybuilder/reactor.py
+++ b/src/main/python/pybuilder/reactor.py
@@ -93,7 +93,8 @@ class Reactor(object):
                       project_directory=".",
                       project_descriptor="build.py",
                       exclude_optional_tasks=None,
-                      exclude_tasks=None):
+                      exclude_tasks=None,
+                      exclude_all_optional=False):
         if not property_overrides:
             property_overrides = {}
         Reactor._current_instance = self
@@ -114,7 +115,7 @@ class Reactor(object):
 
         self.collect_tasks_and_actions_and_initializers(self.project_module)
 
-        self.execution_manager.resolve_dependencies(exclude_optional_tasks, exclude_tasks)
+        self.execution_manager.resolve_dependencies(exclude_optional_tasks, exclude_tasks, exclude_all_optional)
 
     def build(self, tasks=None, environments=None):
         if not tasks:


### PR DESCRIPTION
fixes #263, connected to #263