### PR TITLE
Pybuilder does not parse/run tasks when run in Thoughtworks Go

### DIFF
--- a/src/main/python/pybuilder/cli.py
+++ b/src/main/python/pybuilder/cli.py
@@ -391,7 +391,7 @@ def main(*args):
         except KeyboardInterrupt:
             raise PyBuilderException("Build aborted")
 
-    except Exception as e:
+    except (Exception, SystemExit) as e:
         failure_message = str(e)
         if options.debug:
             traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
fixes #255, connected to #255