### PR TITLE
Must use getfullargspec() on Py3.5 with annotations

### DIFF
--- a/src/integrationtest/python/should_support_annotated_tasks_and_actions_tests.py
+++ b/src/integrationtest/python/should_support_annotated_tasks_and_actions_tests.py
@@ -1,0 +1,50 @@
+#  This file is part of PyBuilder
+#
+#  Copyright 2011-2015 The PyBuilder Team
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import unittest
+
+from integrationtest_support import IntegrationTestSupport
+
+
+class Test(IntegrationTestSupport):
+    def test(self):
+        self.write_build_file("""
+from pybuilder.core import task, before, Project, Logger
+
+name = "test-project"
+
+default_task = ["annotated_task"]
+
+
+@task
+def annotated_task(project: Project, logger: Logger):
+    assert project is not None
+    assert logger is not None
+
+@before
+def annotated_action(project: Project, logger: Logger):
+    assert project is not None
+    assert logger is not None
+
+""")
+        reactor = self.prepare_reactor()
+        reactor.build(["annotated_task"])
+
+
+if __name__ == "__main__":
+    if sys.version_info[0] > 2:
+        unittest.main()

--- a/src/main/python/pybuilder/execution.py
+++ b/src/main/python/pybuilder/execution.py
@@ -43,8 +43,10 @@ from pybuilder.utils import as_list, Timer, odict
 
 if sys.version_info[0] < 3:  # if major is less than 3
     from .excp_util_2 import raise_exception
+    getargspec = inspect.getargspec
 else:
     from .excp_util_3 import raise_exception
+    getargspec = inspect.getfullargspec
 
 
 def as_task_name(item):
@@ -79,7 +81,7 @@ class Executable(object):
             self.source = "n/a"
 
         if isinstance(self.callable, types.FunctionType):
-            self.parameters = inspect.getargspec(self.callable).args
+            self.parameters = getargspec(self.callable).args
         else:
             raise TypeError("Don't know how to handle callable %s" % callable)
 


### PR DESCRIPTION
fixes #287, connected to #287