### PR TITLE
install dependencies behind proxy

### DIFF
--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -17,6 +17,7 @@
 #   limitations under the License.
 
 import re
+import os
 from sys import version_info
 
 from pip._vendor.packaging.specifiers import SpecifierSet, InvalidSpecifier
@@ -72,6 +73,9 @@ def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=F
                                                       ))
     for install_target in as_list(install_targets):
         pip_command_line.extend(as_pip_install_target(install_target))
+
+    if env is None:
+        env = os.environ
 
     if logger:
         logger.debug("Invoking pip: %s", pip_command_line)

--- a/src/unittest/python/pip_utils_tests.py
+++ b/src/unittest/python/pip_utils_tests.py
@@ -16,7 +16,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import os
 import unittest
+
+from mock import patch, ANY
 
 from pybuilder import core
 from pybuilder import pip_utils
@@ -83,3 +86,18 @@ class PipVersionTests(unittest.TestCase):
             "--allow-unverified", "bar",
             "--allow-external", "bar"
         ])
+
+
+class PipUtilsTests(unittest.TestCase):
+    @patch("pybuilder.pip_utils.execute_command")
+    def test_pip_install_environ_inherited(self, execute_command):
+        pip_utils.pip_install("blah")
+        execute_command.assert_called_once_with(ANY, cwd=None, env=os.environ, error_file_name=None, outfile_name=None,
+                                                shell=False)
+
+    @patch("pybuilder.pip_utils.execute_command")
+    def test_pip_install_environ_overwritten(self, execute_command):
+        env_dict = dict()
+        pip_utils.pip_install("blah", env=env_dict)
+        execute_command.assert_called_once_with(ANY, cwd=None, env=env_dict, error_file_name=None, outfile_name=None,
+                                                shell=False)


### PR DESCRIPTION
out-of-process PIP install should inherit PyB environment

fixes #297, connected to #297