### PR TITLE
Task install_dependencies doesn't work in version 0.11.3

### DIFF
--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -16,26 +16,29 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import re
 import os
-from sys import version_info
+import re
+import sys
 
 from pip._vendor.packaging.specifiers import SpecifierSet, InvalidSpecifier
 from pip._vendor.packaging.version import Version, InvalidVersion
 from pip.commands.show import search_packages_info
+
 try:
     # This is the path for pip 7.x
     from pip._vendor.pkg_resources import _initialize_master_working_set
+
     pip_working_set_init = _initialize_master_working_set
 except ImportError:
     # This is the path for pip 6.x
     from pip._vendor import pkg_resources
+
     pip_working_set_init = pkg_resources
 
 from pybuilder.core import Dependency, RequirementsFile
-from pybuilder.utils import execute_command, as_list, is_windows
+from pybuilder.utils import execute_command, as_list
 
-PIP_EXECUTABLE = "pip%s.%s%s" % (version_info[0], version_info[1], ".exe" if is_windows() else "")
+PIP_EXEC_STANZA = [sys.executable, "-m", "pip.__main__"]
 __RE_PIP_PACKAGE_VERSION = re.compile(r"^Version:\s+(.+)$", re.MULTILINE)
 
 
@@ -61,7 +64,7 @@ def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=F
                 force_reinstall=False, target_dir=None, verbose=False, logger=None, outfile_name=None,
                 error_file_name=None, env=None, cwd=None):
     pip_command_line = list()
-    pip_command_line.append(PIP_EXECUTABLE)
+    pip_command_line.extend(PIP_EXEC_STANZA)
     pip_command_line.append("install")
     pip_command_line.extend(build_pip_install_options(index_url,
                                                       extra_index_url,

--- a/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
@@ -18,17 +18,17 @@
 
 from __future__ import print_function
 
-import re
 import os
+import re
 
+from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.core import (before,
                             task,
                             description,
                             use_plugin,
                             init)
 from pybuilder.errors import BuildFailedException
-from pybuilder.pip_utils import (PIP_EXECUTABLE,
-                                 build_pip_install_options,
+from pybuilder.pip_utils import (build_pip_install_options,
                                  as_pip_install_target,
                                  )
 from pybuilder.terminal import print_file_content
@@ -103,7 +103,7 @@ def install_dependency(logger, project, dependency):
         pass
 
     pip_command_line = list()
-    pip_command_line.append(PIP_EXECUTABLE)
+    pip_command_line.extend(PIP_EXEC_STANZA)
     pip_command_line.append("install")
     pip_command_line.extend(build_pip_install_options(project.get_property("install_dependencies_index_url"),
                                                       project.get_property("install_dependencies_extra_index_url"),

--- a/src/main/python/pybuilder/scaffolding.py
+++ b/src/main/python/pybuilder/scaffolding.py
@@ -16,9 +16,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import string
-
 import os
+import string
 
 from pybuilder.terminal import print_text_line
 
@@ -137,15 +136,13 @@ import shutil
 
 from sys import version_info
 
-PIP_EXECUTABLE = "pip%s.%s%s" % (version_info[0], version_info[1], ".exe" if "win32" in sys.platform else "")
-
 script_dir = os.path.dirname(os.path.realpath(__file__))
 exit_code = 0
 try:
     subprocess.check_call(["pyb", "--version"])
 except FileNotFoundError as e:
     try:
-        subprocess.check_call([PIP_EXECUTABLE, "install", "pybuilder"])
+        subprocess.check_call([sys.executable, "-m", "pip.__main__", "install", "pybuilder"])
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
 except subprocess.CalledProcessError as e:

--- a/src/unittest/python/pluginloader_tests.py
+++ b/src/unittest/python/pluginloader_tests.py
@@ -31,6 +31,7 @@ except ImportError as e:
 from mockito import when, verify, unstub, never  # TODO @mriehl get rid of mockito here
 from mock import patch, Mock, ANY
 from test_utils import mock  # TODO @mriehl WTF is this sorcery?!
+from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.errors import MissingPluginException, IncompatiblePluginException, UnspecifiedPluginNameException
 from pybuilder.pluginloader import (BuiltinPluginLoader,
                                     DispatchingPluginLoader,
@@ -197,7 +198,7 @@ class InstallExternalPluginTests(unittest.TestCase):
 
         _install_external_plugin("pypi:some-plugin", None, Mock(), None)
 
-        execute.assert_called_with([ANY, 'install', 'some-plugin'], shell=False,
+        execute.assert_called_with(PIP_EXEC_STANZA + ['install', 'some-plugin'], shell=False,
                                    outfile_name=ANY, error_file_name=ANY, cwd=".", env=ANY)
 
     @patch("pybuilder.pluginloader.read_file")
@@ -209,7 +210,7 @@ class InstallExternalPluginTests(unittest.TestCase):
 
         _install_external_plugin("pypi:some-plugin", "===1.2.3", Mock(), None)
 
-        execute.assert_called_with([ANY, 'install', '--upgrade', 'some-plugin===1.2.3'], shell=False,
+        execute.assert_called_with(PIP_EXEC_STANZA + ['install', '--upgrade', 'some-plugin===1.2.3'], shell=False,
                                    outfile_name=ANY, error_file_name=ANY, cwd=".", env=ANY)
 
     @patch("pybuilder.pluginloader.read_file")
@@ -221,7 +222,7 @@ class InstallExternalPluginTests(unittest.TestCase):
 
         _install_external_plugin("vcs:some-plugin URL", None, Mock(), None)
 
-        execute.assert_called_with([ANY, 'install', '--force-reinstall', 'some-plugin URL'], shell=False,
+        execute.assert_called_with(PIP_EXEC_STANZA + ['install', '--force-reinstall', 'some-plugin URL'], shell=False,
                                    outfile_name=ANY, error_file_name=ANY, cwd=".", env=ANY)
 
     @patch("pybuilder.pluginloader.read_file")
@@ -233,7 +234,7 @@ class InstallExternalPluginTests(unittest.TestCase):
 
         _install_external_plugin("vcs:some-plugin URL", "===1.2.3", Mock(), None)
 
-        execute.assert_called_with([ANY, 'install', '--force-reinstall', 'some-plugin URL'], shell=False,
+        execute.assert_called_with(PIP_EXEC_STANZA + ['install', '--force-reinstall', 'some-plugin URL'], shell=False,
                                    outfile_name=ANY, error_file_name=ANY, cwd=".", env=ANY)
 
     @patch("pybuilder.pluginloader.read_file")

--- a/src/unittest/python/plugins/python/distutils_plugin_tests.py
+++ b/src/unittest/python/plugins/python/distutils_plugin_tests.py
@@ -29,6 +29,7 @@ from mock import patch, MagicMock, ANY
 
 from pybuilder.core import Project, Author, Logger
 from pybuilder.errors import BuildFailedException
+from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.plugins.python.distutils_plugin import (build_data_files_string,
                                                        build_dependency_links_string,
                                                        build_install_dependencies_string,
@@ -693,7 +694,8 @@ class TasksTest(PyBuilderTestCase):
     @patch("pybuilder.pip_utils.execute_command")
     def test_install(self, execute_command, *args):
         install_distribution(self.project, MagicMock(Logger))
-        execute_command.assert_called_with([ANY, "install", "--force-reinstall", '/whatever dist'], cwd=".", env=ANY,
+        execute_command.assert_called_with(PIP_EXEC_STANZA + ["install", "--force-reinstall", '/whatever dist'],
+                                           cwd=".", env=ANY,
                                            outfile_name=ANY, error_file_name=ANY, shell=False)
 
     @patch("pybuilder.plugins.python.distutils_plugin.os.mkdir")

--- a/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
+++ b/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
@@ -26,7 +26,7 @@ from pybuilder.core import (Project,
                             Logger,
                             Dependency,
                             RequirementsFile)
-from pybuilder.pip_utils import PIP_EXECUTABLE
+from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.plugins.python.install_dependencies_plugin import (initialize_install_dependencies_plugin,
                                                                   install_runtime_dependencies,
                                                                   install_build_dependencies,
@@ -56,7 +56,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_requirements_file_dependency(self):
         dependency = RequirementsFile("requirements.txt")
@@ -64,7 +64,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", '-r', "requirements.txt"], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", '-r', "requirements.txt"], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_without_version_on_windows_derivate(self):
         dependency = Dependency("spam")
@@ -72,7 +72,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "spam"], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "spam"], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_insecurely_when_property_is_set(self):
         dependency = Dependency("spam")
@@ -82,7 +82,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--allow-unverified", "spam", "--allow-external", "spam", 'spam'],
+            PIP_EXEC_STANZA + ["install", "--allow-unverified", "spam", "--allow-external", "spam", 'spam'],
             any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_securely_when_property_is_not_set_to_dependency(self):
@@ -93,8 +93,8 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--allow-unverified", "some-other-dependency", "--allow-external",
-                "some-other-dependency", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--allow-unverified", "some-other-dependency", "--allow-external",
+                               "some-other-dependency", 'spam'], any_value(), env=any_value(), shell=False)
         #  some-other-dependency might be a dependency of 'spam'
         #  so we always have to put the insecure dependencies in the command line :-(
 
@@ -106,7 +106,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_using_custom_index_url(self):
         self.project.set_property("install_dependencies_index_url", "some_index_url")
@@ -115,7 +115,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--index-url", "some_index_url", 'spam'], any_value(), env=any_value(),
+            PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", 'spam'], any_value(), env=any_value(),
             shell=False)
 
     def test_should_not_use_extra_index_url_when_index_url_is_not_set(self):
@@ -125,7 +125,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
 
     def test_should_not_use_index_and_extra_index_url_when_index_and_extra_index_url_are_set(self):
         self.project.set_property("install_dependencies_index_url", "some_index_url")
@@ -135,8 +135,8 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--index-url", "some_index_url", "--extra-index-url",
-                "some_extra_index_url", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", "--extra-index-url",
+                               "some_extra_index_url", 'spam'], any_value(), env=any_value(), shell=False)
 
     def test_should_upgrade_dependencies(self):
         self.project.set_property("install_dependencies_upgrade", True)
@@ -145,7 +145,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--upgrade", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--upgrade", 'spam'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_with_version(self):
         dependency = Dependency("spam", "0.1.2")
@@ -153,7 +153,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", 'spam>=0.1.2'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", 'spam>=0.1.2'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_with_version_and_operator(self):
         dependency = Dependency("spam", "==0.1.2")
@@ -161,7 +161,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", 'spam==0.1.2'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", 'spam==0.1.2'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_with_url(self):
         dependency = Dependency("spam", url="some_url")
@@ -169,7 +169,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
 
     def test_should_install_dependency_with_url_even_if_version_is_given(self):
         dependency = Dependency("spam", version="0.1.2", url="some_url")
@@ -177,7 +177,7 @@ class InstallDependencyTest(unittest.TestCase):
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            [PIP_EXECUTABLE, "install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
 
     class InstallRuntimeDependenciesTest(unittest.TestCase):
         def setUp(self):
@@ -199,11 +199,11 @@ class InstallDependencyTest(unittest.TestCase):
             install_runtime_dependencies(self.logger, self.project)
 
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", 'spam'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", 'spam'], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", 'eggs'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", 'eggs'], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", '-r', 'requirements.txt'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", '-r', 'requirements.txt'], any_value(), shell=False)
 
         def test_should_install_multiple_dependencies_locally(self):
             self.project.depends_on("spam")
@@ -217,11 +217,11 @@ class InstallDependencyTest(unittest.TestCase):
             install_runtime_dependencies(self.logger, self.project)
 
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", "-t", "any-dir", 'spam'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", "-t", "any-dir", 'spam'], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", "-t", "any-other-dir", 'eggs'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", "-t", "any-other-dir", 'eggs'], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", 'foo'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", 'foo'], any_value(), shell=False)
 
     class InstallBuildDependenciesTest(unittest.TestCase):
         def setUp(self):
@@ -245,11 +245,11 @@ class InstallDependencyTest(unittest.TestCase):
             install_build_dependencies(self.logger, self.project)
 
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", "spam"], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", "spam"], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", "eggs"], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", "eggs"], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", '-r', 'requirements-dev.txt'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", '-r', 'requirements-dev.txt'], any_value(), shell=False)
 
     class InstallDependenciesTest(unittest.TestCase):
         def setUp(self):
@@ -272,6 +272,6 @@ class InstallDependencyTest(unittest.TestCase):
             install_dependencies(self.logger, self.project)
 
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", 'spam'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", 'spam'], any_value(), shell=False)
             verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                [PIP_EXECUTABLE, "install", 'eggs'], any_value(), shell=False)
+                PIP_EXEC_STANZA + ["install", 'eggs'], any_value(), shell=False)


### PR DESCRIPTION
`PIP_EXECUTABLE` is no more, replaced with `sys.executable, '-m', 'pip'`
Unit tests updated
Setup.py scaffolding updated

fixes #310, connected to #310