### PR TITLE
Update cram plugin to use the 'outside' environment

### DIFF
--- a/src/main/python/pybuilder/plugins/python/cram_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/cram_plugin.py
@@ -54,7 +54,7 @@ def assert_cram_is_executable(logger):
 
 
 def _cram_command_for(project):
-    command_and_arguments = ["cram"]
+    command_and_arguments = ["cram", '-E']
     if project.get_property("verbose"):
         command_and_arguments.append('--verbose')
     return command_and_arguments

--- a/src/unittest/python/plugins/python/cram_plugin_tests.py
+++ b/src/unittest/python/plugins/python/cram_plugin_tests.py
@@ -34,14 +34,14 @@ class CramPluginTests(unittest.TestCase):
     def test_command_respects_no_verbose(self):
         project = Project('.')
         project.set_property('verbose', False)
-        expected = ['cram']
+        expected = ['cram', '-E']
         received = _cram_command_for(project)
         self.assertEquals(expected, received)
 
     def test_command_respects_verbose(self):
         project = Project('.')
         project.set_property('verbose', True)
-        expected = ['cram', '--verbose']
+        expected = ['cram', '-E', '--verbose']
         received = _cram_command_for(project)
         self.assertEquals(expected, received)
 
@@ -129,7 +129,8 @@ class CramPluginTests(unittest.TestCase):
         read_file_mock.return_value = ['test failes for file', '# results']
         execute_mock.return_value = 1
 
-        self.assertRaises(BuildFailedException, run_cram_tests, project, logger)
+        self.assertRaises(
+            BuildFailedException, run_cram_tests, project, logger)
         execute_mock.assert_called_once_with(
             ['cram', 'test1.cram', 'test2.cram'], 'report_file',
             error_file_name='report_file',
@@ -171,7 +172,8 @@ class CramPluginTests(unittest.TestCase):
         read_file_mock.return_value = ['test failes for file', '# results']
         execute_mock.return_value = 1
 
-        self.assertRaises(BuildFailedException, run_cram_tests, project, logger)
+        self.assertRaises(
+            BuildFailedException, run_cram_tests, project, logger)
         execute_mock.assert_called_once_with(
             ['cram', 'test1.cram', 'test2.cram'], 'report_file',
             error_file_name='report_file',
@@ -250,7 +252,8 @@ class CramPluginTests(unittest.TestCase):
         read_file_mock.return_value = ['test failes for file', '# results']
         execute_mock.return_value = 1
 
-        self.assertRaises(BuildFailedException, run_cram_tests, project, logger)
+        self.assertRaises(
+            BuildFailedException, run_cram_tests, project, logger)
 
         execute_mock.assert_not_called()
         expected_info_calls = [call('Running Cram command line tests'),


### PR DESCRIPTION
This modification instructs `cram` to use the 'outside' environment variables, without which commands with UTF-8 encoded characters get encoded with their surrogate-escape counterparts, resulting in automated tests failing.

For details, see https://github.com/brodie/cram/issues/7.

Until this pull request is not merged, `afp-cli` won't build.