### PR TITLE
Adding the flag for cram to run tests from the target directory

### DIFF
--- a/src/main/python/pybuilder/plugins/python/cram_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/cram_plugin.py
@@ -41,7 +41,7 @@ def initialize_cram_plugin(project):
     project.set_property_if_unset("dir_source_cmdlinetest", "src/cmdlinetest")
     project.set_property_if_unset("cram_test_file_glob", "*.t")
     project.set_property_if_unset("cram_fail_if_no_tests", True)
-    project.set_property_if_unset("cram_run_test_from_target", False)
+    project.set_property_if_unset("cram_run_test_from_target", True)
 
 
 @after("prepare")

--- a/src/main/python/pybuilder/plugins/python/cram_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/cram_plugin.py
@@ -41,6 +41,7 @@ def initialize_cram_plugin(project):
     project.set_property_if_unset("dir_source_cmdlinetest", "src/cmdlinetest")
     project.set_property_if_unset("cram_test_file_glob", "*.t")
     project.set_property_if_unset("cram_fail_if_no_tests", True)
+    project.set_property_if_unset("cram_run_test_from_target", False)
 
 
 @after("prepare")
@@ -93,10 +94,16 @@ def run_cram_tests(project, logger):
     report_file = _report_file(project)
 
     env = os.environ.copy()
-    source_dir = project.expand_path("$dir_source_main_python")
-    _prepend_path(env, "PYTHONPATH", source_dir)
-    script_dir = project.expand_path('$dir_source_main_scripts')
-    _prepend_path(env, "PATH", script_dir)
+    if project.get_property('cram_run_test_from_target'):
+        dist_dir = project.expand_path("$dir_dist")
+        _prepend_path(env, "PYTHONPATH", dist_dir)
+        script_dir_dist = project.expand_path('$dir_dist_scripts')
+        _prepend_path(env, "PATH", os.path.join(dist_dir, script_dir_dist))
+    else:
+        source_dir = project.expand_path("$dir_source_main_python")
+        _prepend_path(env, "PYTHONPATH", source_dir)
+        script_dir = project.expand_path('$dir_source_main_scripts')
+        _prepend_path(env, "PATH", script_dir)
 
     return_code = execute_command(command_and_arguments,
                                   report_file,

--- a/src/main/python/pybuilder/plugins/python/cram_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/cram_plugin.py
@@ -97,7 +97,7 @@ def run_cram_tests(project, logger):
     if project.get_property('cram_run_test_from_target'):
         dist_dir = project.expand_path("$dir_dist")
         _prepend_path(env, "PYTHONPATH", dist_dir)
-        script_dir_dist = project.expand_path('$dir_dist_scripts')
+        script_dir_dist = project.get_property('dir_dist_scripts')
         _prepend_path(env, "PATH", os.path.join(dist_dir, script_dir_dist))
     else:
         source_dir = project.expand_path("$dir_source_main_python")

--- a/src/unittest/python/plugins/python/cram_plugin_tests.py
+++ b/src/unittest/python/plugins/python/cram_plugin_tests.py
@@ -95,7 +95,7 @@ class CramPluginTests(unittest.TestCase):
         execute_mock.assert_called_once_with(
             ['cram', 'test1.cram', 'test2.cram'], 'report_file',
             error_file_name='report_file',
-            env={'PYTHONPATH': './python:', 'PATH': './python/./scripts:'}
+            env={'PYTHONPATH': './python:', 'PATH': './python/scripts:'}
         )
         expected_info_calls = [call('Running Cram command line tests'),
                                call('Cram tests were fine'),


### PR DESCRIPTION
- with the option `cram_run_test_from_target` to True (default is False)
  cram tests will be executed using the built artifact to be found in
  the target directory
- this way, filtered scripts
  (http://pybuilder.github.io/documentation/plugins.html#Filteringfiles)
  which contain needed information for the tests, can be used.