### PR TITLE
FileNotFoundError doesn't exist (in python?)

### DIFF
--- a/src/main/python/pybuilder/scaffolding.py
+++ b/src/main/python/pybuilder/scaffolding.py
@@ -135,18 +135,26 @@ import glob
 import shutil
 
 from sys import version_info
+py3 = version_info[0] == 3
+py2 = not py3
+if py2:
+    FileNotFoundError = OSError
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 exit_code = 0
 try:
     subprocess.check_call(["pyb", "--version"])
 except FileNotFoundError as e:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip.__main__", "install", "pybuilder"])
-    except subprocess.CalledProcessError as e:
-        sys.exit(e.returncode)
+    if py3 or py2 and e.errno == 2:
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip.__main__", "install", "pybuilder"])
+        except subprocess.CalledProcessError as e:
+            sys.exit(e.returncode)
+    else:
+        raise
 except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
+
 try:
     subprocess.check_call(["pyb", "clean", "install_build_dependencies", "package", "-o"])
     dist_dir = glob.glob(os.path.join(script_dir, "target", "dist", "*"))[0]


### PR DESCRIPTION
The setup.py generated is buggy, apparently:

https://github.com/ImmobilienScout24/afp-cli/pull/57