### PR TITLE
Work around unittest-xml-reporting 2.0 dropping Python 2.6 support

### DIFF
--- a/src/main/python/pybuilder/plugins/python/unittest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/unittest_plugin.py
@@ -39,7 +39,12 @@ use_plugin("python.core")
 
 @init
 def init_test_source_directory(project):
-    project.plugin_depends_on("unittest-xml-reporting")
+    if sys.version_info[:2] <= (2, 6):
+        # Support for Python 2.6 was dropped in unittest-xml-reporting
+        # version 2.0, so use an older version.
+        project.plugin_depends_on("unittest-xml-reporting<2.0")
+    else:
+        project.plugin_depends_on("unittest-xml-reporting")
 
     project.set_property_if_unset("dir_source_unittest_python", "src/unittest/python")
     project.set_property_if_unset("unittest_module_glob", "*_tests")


### PR DESCRIPTION
Version 2.0 of unittest-xml-reporting has [dropped support for Python 2.6](https://github.com/xmlrunner/unittest-xml-reporting/commit/531895eaccf54aeff7d31b5560a90fc1da720eeb). To work around that, pybuilder's unittest plugin should use an older version when Python2.6 is used.