### PR TITLE
Support for pip --trusted-host argument enhancement

### DIFF
--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -60,9 +60,9 @@ def build_dependency_version_string(mixed):
             raise ValueError("'%s' must be either PEP 0440 version or a version specifier set")
 
 
-def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=False, insecure_installs=None,
-                force_reinstall=False, target_dir=None, verbose=False, logger=None, outfile_name=None,
-                error_file_name=None, env=None, cwd=None):
+def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=False,
+                insecure_installs=None, force_reinstall=False, target_dir=None, verbose=False, logger=None,
+                outfile_name=None, error_file_name=None, env=None, cwd=None, trusted_host=None):
     pip_command_line = list()
     pip_command_line.extend(PIP_EXEC_STANZA)
     pip_command_line.append("install")
@@ -72,7 +72,8 @@ def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=F
                                                       insecure_installs,
                                                       force_reinstall,
                                                       target_dir,
-                                                      verbose
+                                                      verbose,
+                                                      trusted_host
                                                       ))
     for install_target in as_list(install_targets):
         pip_command_line.extend(as_pip_install_target(install_target))
@@ -87,14 +88,23 @@ def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=F
 
 
 def build_pip_install_options(index_url=None, extra_index_url=None, upgrade=False, insecure_installs=None,
-                              force_reinstall=False, target_dir=None, verbose=False):
+                              force_reinstall=False, target_dir=None, verbose=False, trusted_host=None):
     options = []
     if index_url:
         options.append("--index-url")
         options.append(index_url)
-        if extra_index_url:
+
+    if extra_index_url:
+        extra_index_urls = as_list(extra_index_url)
+        for url in extra_index_urls:
             options.append("--extra-index-url")
-            options.append(extra_index_url)
+            options.append(url)
+
+    if trusted_host:
+        trusted_hosts = as_list(trusted_host)
+        for host in trusted_hosts:
+            options.append("--trusted-host")
+            options.append(host)
 
     if upgrade:
         options.append("--upgrade")

--- a/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
@@ -45,6 +45,7 @@ def initialize_install_dependencies_plugin(project):
     project.set_property_if_unset("install_dependencies_index_url", None)
     project.set_property_if_unset("install_dependencies_local_mapping", {})
     project.set_property_if_unset("install_dependencies_extra_index_url", None)
+    project.set_property_if_unset("install_dependencies_trusted_host", None)
     project.set_property_if_unset("install_dependencies_upgrade", False)
     project.set_property_if_unset("install_dependencies_insecure_installation", [])
 
@@ -112,7 +113,8 @@ def install_dependency(logger, project, dependency):
                                                           "install_dependencies_insecure_installation"),
                                                       True if url else False,
                                                       target_dir,
-                                                      project.get_property("verbose")
+                                                      project.get_property("verbose"),
+                                                      project.get_property("install_dependencies_trusted_host")
                                                       ))
     pip_command_line.extend(as_pip_install_target(dependency))
     logger.debug("Invoking pip: %s", pip_command_line)

--- a/src/unittest/python/pip_utils_tests.py
+++ b/src/unittest/python/pip_utils_tests.py
@@ -72,9 +72,15 @@ class PipVersionTests(unittest.TestCase):
     def test_build_pip_install_options(self):
         self.assertEquals(pip_utils.build_pip_install_options(), [])
         self.assertEquals(pip_utils.build_pip_install_options(index_url="foo"), ["--index-url", "foo"])
-        self.assertEquals(pip_utils.build_pip_install_options(extra_index_url="foo"), [])
+        self.assertEquals(pip_utils.build_pip_install_options(extra_index_url="foo"), ["--extra-index-url", "foo"])
         self.assertEquals(pip_utils.build_pip_install_options(index_url="foo", extra_index_url="bar"),
                           ["--index-url", "foo", "--extra-index-url", "bar"])
+        self.assertEquals(pip_utils.build_pip_install_options(extra_index_url=("foo", "bar")),
+                          ["--extra-index-url", "foo", "--extra-index-url", "bar"])
+        self.assertEquals(pip_utils.build_pip_install_options(trusted_host="foo"),
+                          ["--trusted-host", "foo"])
+        self.assertEquals(pip_utils.build_pip_install_options(trusted_host=("foo", "bar")),
+                          ["--trusted-host", "foo", "--trusted-host", "bar"])
         self.assertEquals(pip_utils.build_pip_install_options(upgrade=True), ["--upgrade"])
         self.assertEquals(pip_utils.build_pip_install_options(verbose=True), ["--verbose"])
         self.assertEquals(pip_utils.build_pip_install_options(force_reinstall=True), ["--force-reinstall"])

--- a/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
+++ b/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
@@ -118,16 +118,17 @@ class InstallDependencyTest(unittest.TestCase):
             PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", 'spam'], any_value(), env=any_value(),
             shell=False)
 
-    def test_should_not_use_extra_index_url_when_index_url_is_not_set(self):
-        self.project.set_property("install_dependencies_extra_index_url", "some_index_url")
+    def test_should_use_extra_index_url_when_index_url_is_not_set(self):
+        self.project.set_property("install_dependencies_extra_index_url", "some_extra_index_url")
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
         verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
+            PIP_EXEC_STANZA + ["install", "--extra-index-url", "some_extra_index_url", 'spam'], any_value(),
+            env=any_value(), shell=False)
 
-    def test_should_not_use_index_and_extra_index_url_when_index_and_extra_index_url_are_set(self):
+    def test_should_use_index_and_extra_index_url_when_index_and_extra_index_url_are_set(self):
         self.project.set_property("install_dependencies_index_url", "some_index_url")
         self.project.set_property("install_dependencies_extra_index_url", "some_extra_index_url")
         dependency = Dependency("spam")


### PR DESCRIPTION
This also changes the following behaviors:
* extra-index-url is now supported without specifying index-url
* trusted-host and extra-index-url can specify both a single value and a collection as pip allows that

trusted-host added for both dependency and plugin installs

fixes #341, connected to #341