### PR TITLE
PyBuilder install_dependencies behavior should mirror #340

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ branches:
   - doc/sphinxdoc
 before_script:
 - pip install coveralls
-- "./build.py install_dependencies -v -X"
 script:
-- "./build.py -v -X analyze install"
+- "./build.py -v -X install_dependencies analyze install"
 after_success:
 - coveralls --verbose
 deploy:

--- a/build.py
+++ b/build.py
@@ -79,14 +79,14 @@ url = "http://pybuilder.github.io"
 license = "Apache License"
 version = "0.11.9.dev"
 
-default_task = ["analyze", "publish"]
+default_task = ["install_dependencies", "analyze", "publish"]
 
 
 @init
 def initialize(project):
-    project.build_depends_on("fluentmock")
-    project.build_depends_on("mock")
-    project.build_depends_on("mockito-without-hardcoded-distribute-version")
+    if sys.version_info[0] == 2:
+        project.build_depends_on("mock")
+
     project.build_depends_on("pyfix")  # required test framework
     project.build_depends_on("pyassert")
     project.build_depends_on("pygments")

--- a/samples/modern-python-app/src/unittest/python/helloworld_pyfix_tests.py
+++ b/samples/modern-python-app/src/unittest/python/helloworld_pyfix_tests.py
@@ -15,16 +15,16 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from mockito import mock, verify
-from pyfix import test
 
 from helloworld import helloworld
+from test_utils import Mock
+from pyfix import test
 
 
 @test
 def should_issue_hello_world_message():
-    out = mock()
+    out = Mock()
 
     helloworld(out)
 
-    verify(out).write("Hello world of Python\n")
+    out.write.assert_called_with("Hello world of Python\n")

--- a/samples/simple-python-app/src/unittest/python/helloworld_tests.py
+++ b/samples/simple-python-app/src/unittest/python/helloworld_tests.py
@@ -17,15 +17,14 @@
 #   limitations under the License.
 import unittest
 
-from mockito import mock, verify
-
 from helloworld import helloworld
+from test_utils import Mock
 
 
 class HelloWorldTest(unittest.TestCase):
     def test_should_issue_hello_world_message(self):
-        out = mock()
+        out = Mock()
 
         helloworld(out)
 
-        verify(out).write("Hello world of Python\n")
+        out.write.assert_called_with("Hello world of Python\n")

--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -22,16 +22,16 @@
     build.py project descriptor.
 """
 
+import fnmatch
 import itertools
+import os
 import string
 import sys
 from datetime import datetime
-
-import fnmatch
-import os
 from os.path import sep as PATH_SEPARATOR
 
 from pybuilder.errors import MissingPropertyException
+from pybuilder.pip_common import Version, InvalidVersion, SpecifierSet, InvalidSpecifier
 from pybuilder.utils import as_list
 
 INITIALIZER_ATTRIBUTE = "_python_builder_initializer"
@@ -230,6 +230,17 @@ class Dependency(object):
 
     def __init__(self, name, version=None, url=None):
         self.name = name
+
+        if version:
+            try:
+                version = ">=" + str(Version(version))
+                self.version_not_a_spec = True
+            except InvalidVersion:
+                try:
+                    version = str(SpecifierSet(version))
+                except InvalidSpecifier:
+                    raise ValueError("'%s' must be either PEP 0440 version or a version specifier set")
+
         self.version = version
         self.url = url
 
@@ -266,6 +277,7 @@ class RequirementsFile(object):
 
     def __init__(self, filename):
         self.name = filename
+        self.version = None
 
     def __eq__(self, other):
         if not isinstance(other, RequirementsFile):

--- a/src/main/python/pybuilder/pip_common.py
+++ b/src/main/python/pybuilder/pip_common.py
@@ -1,0 +1,48 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2015 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from pip._vendor.packaging.specifiers import SpecifierSet, InvalidSpecifier
+from pip._vendor.packaging.version import Version, InvalidVersion
+from pip.commands.show import search_packages_info
+
+try:
+    # This is the path for pip 7.x
+    from pip._vendor.pkg_resources import _initialize_master_working_set
+
+    pip_working_set_init = _initialize_master_working_set
+except ImportError:
+    # This is the path for pip 6.x
+    from imp import reload
+    from pip._vendor import pkg_resources
+
+    def pip_working_set_init():
+        reload(pkg_resources)
+
+SpecifierSet = SpecifierSet
+InvalidSpecifier = InvalidSpecifier
+Version = Version
+InvalidVersion = InvalidVersion
+search_packages_info = search_packages_info
+
+
+def _pip_disallows_insecure_packages_by_default():
+    import pip
+    # (2014-01-01) BACKWARD INCOMPATIBLE pip no longer will scrape insecure external urls by default
+    # nor will it install externally hosted files by default
+    # Also pip v1.1 for example has no __version__
+    return hasattr(pip, "__version__") and pip.__version__ >= '1.5'

--- a/src/main/python/pybuilder/pluginloader.py
+++ b/src/main/python/pybuilder/pluginloader.py
@@ -29,8 +29,7 @@ from pybuilder.errors import (MissingPluginException,
                               IncompatiblePluginException,
                               UnspecifiedPluginNameException,
                               )
-from pybuilder.pip_utils import Version, SpecifierSet
-from pybuilder.pip_utils import pip_install, version_satisfies_spec
+from pybuilder.pip_utils import (Version, pip_install, version_satisfies_spec, should_update_package)
 from pybuilder.utils import read_file
 
 PYPI_PLUGIN_PROTOCOL = "pypi:"
@@ -80,13 +79,7 @@ class DownloadingPluginLoader(PluginLoader):
         # Maybe we already installed this plugin from PyPI before
         if thirdparty_plugin.startswith(PYPI_PLUGIN_PROTOCOL):
             thirdparty_plugin = thirdparty_plugin.replace(PYPI_PLUGIN_PROTOCOL, "")
-            if version:
-                version_specifier = SpecifierSet(version)
-                # We always check if even one specifier in the set is not exact
-                for spec in version_specifier._specs:
-                    if spec.operator not in ("==", "==="):
-                        update_plugin = True
-                        break
+            update_plugin = should_update_package(version)
         elif thirdparty_plugin.startswith(VCS_PLUGIN_PROTOCOL):
             if not plugin_module_name:
                 raise UnspecifiedPluginNameException(name)

--- a/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
@@ -18,21 +18,28 @@
 
 from __future__ import print_function
 
+import collections
+import imp
 import os
 import re
+import sys
 
-from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.core import (before,
                             task,
                             description,
                             use_plugin,
-                            init)
+                            init,
+                            Dependency,
+                            RequirementsFile)
 from pybuilder.errors import BuildFailedException
-from pybuilder.pip_utils import (build_pip_install_options,
+from pybuilder.pip_utils import (PIP_EXEC_STANZA,
+                                 build_pip_install_options,
                                  as_pip_install_target,
-                                 )
+                                 get_package_version,
+                                 should_update_package,
+                                 version_satisfies_spec)
 from pybuilder.terminal import print_file_content
-from pybuilder.utils import execute_command, mkdir
+from pybuilder.utils import execute_command, mkdir, as_list
 
 __author__ = "Alexander Metzner, Arcadiy Ivanov"
 
@@ -46,6 +53,7 @@ def initialize_install_dependencies_plugin(project):
     project.set_property_if_unset("install_dependencies_local_mapping", {})
     project.set_property_if_unset("install_dependencies_extra_index_url", None)
     project.set_property_if_unset("install_dependencies_trusted_host", None)
+    # Deprecated - has no effect
     project.set_property_if_unset("install_dependencies_upgrade", False)
     project.set_property_if_unset("install_dependencies_insecure_installation", [])
 
@@ -54,24 +62,21 @@ def initialize_install_dependencies_plugin(project):
 @description("Installs all (both runtime and build) dependencies specified in the build descriptor")
 def install_dependencies(logger, project):
     logger.info("Installing all dependencies")
-    install_build_dependencies(logger, project)
-    install_runtime_dependencies(logger, project)
+    install_dependency(logger, project, as_list(project.build_dependencies) + as_list(project.dependencies))
 
 
 @task
 @description("Installs all build dependencies specified in the build descriptor")
 def install_build_dependencies(logger, project):
     logger.info("Installing build dependencies")
-    for dependency in project.build_dependencies:
-        install_dependency(logger, project, dependency)
+    install_dependency(logger, project, project.build_dependencies)
 
 
 @task
 @description("Installs all runtime dependencies specified in the build descriptor")
 def install_runtime_dependencies(logger, project):
     logger.info("Installing runtime dependencies")
-    for dependency in project.dependencies:
-        install_dependency(logger, project, dependency)
+    install_dependency(logger, project, project.dependencies)
 
 
 @task
@@ -90,28 +95,99 @@ def create_install_log_directory(logger, project):
     mkdir(log_dir)
 
 
-def install_dependency(logger, project, dependency):
-    url = getattr(dependency, "url", None)
-    logger.info("Installing dependency '%s'%s", dependency.name,
-                " from %s" % url if url else "")
-    log_file = project.expand_path("$dir_install_logs", dependency.name)
-    log_file = re.sub(r'<|>|=', '_', log_file)
+def install_dependency(logger, project, dependencies):
+    dependencies_to_install, orig_installed_pkgs = _filter_dependencies(logger, project, dependencies)
+    batch_dependencies = []
+    standalone_dependencies = []
+    local_mapping = project.get_property("install_dependencies_local_mapping")
+    for dependency in dependencies_to_install:
+        url = getattr(dependency, "url", None)
 
-    target_dir = None
-    try:
-        target_dir = project.get_property("install_dependencies_local_mapping")[dependency.name]
-    except KeyError:
-        pass
+        if dependency.name in local_mapping or url:
+            install_type = "standalone"
+            logger.debug("Dependency '%s' has to be installed standalone" % dependency)
+            standalone_dependencies.append(dependency)
+        else:
+            install_type = "batch"
+            logger.debug("Dependency '%s' will be included in batch install" % dependency)
+            batch_dependencies.append(dependency)
+
+        logger.info("Processing %s dependency '%s%s'%s", install_type, dependency.name,
+                    dependency.version if dependency.version else "",
+                    " from %s" % url if url else "")
+
+    for standalone_dependency in standalone_dependencies:
+        url = getattr(standalone_dependency, "url", None)
+        log_file = project.expand_path("$dir_install_logs", dependency.name)
+        log_file = re.sub(r'<|>|=', '_', log_file)
+        _do_install_dependency(logger, project, standalone_dependency,
+                               True,
+                               url,
+                               local_mapping.get(dependency.name),
+                               log_file)
+
+    if len(batch_dependencies):
+        log_file = project.expand_path("$dir_install_logs", "install_batch")
+        _do_install_dependency(logger, project, batch_dependencies, True, False, None, log_file)
+
+    __reload_pip_if_updated(logger, dependencies_to_install)
+
+
+def _filter_dependencies(logger, project, dependencies):
+    dependencies = as_list(dependencies)
+    installed_packages = get_package_version(dependencies)
+    dependencies_to_install = []
+
+    for dependency in dependencies:
+        logger.debug("Inspecting dependency '%s'" % dependency)
+        if isinstance(dependency, RequirementsFile):
+            # Always add requirement file-based dependencies
+            logger.debug("Dependency '%s' is a requirement file and will be included" % dependency)
+            dependencies_to_install.append(dependency)
+            continue
+        elif isinstance(dependency, Dependency):
+            if dependency.url:
+                # Always add dependency that is url-based
+                logger.debug("Dependency '%s' is URL-based and will be included" % dependency)
+                dependencies_to_install.append(dependency)
+                continue
+            if should_update_package(dependency.version) and not getattr(dependency, "version_not_a_spec", False):
+                # Always add dependency that has a version specifier indicating desire to always update
+                logger.debug("Dependency '%s' has a non-exact version specifier and will be included" % dependency)
+                dependencies_to_install.append(dependency)
+                continue
+
+        dependency_name = dependency.name.lower()
+        if dependency_name not in installed_packages:
+            # If dependency not installed at all then install it
+            logger.debug("Dependency '%s' is not installed and will be included" % dependency)
+            dependencies_to_install.append(dependency)
+            continue
+
+        if dependency.version and not version_satisfies_spec(dependency.version, installed_packages[dependency_name]):
+            # If version is specified and version constraint is not satisfied
+            logger.debug("Dependency '%s' is not satisfied by installed dependency version '%s' and will be included" %
+                         (dependency, installed_packages[dependency_name]))
+            dependencies_to_install.append(dependency)
+            continue
+
+        logger.debug("Dependency '%s' is already up-to-date and will be skipped" % dependency)
+
+    return dependencies_to_install, installed_packages
+
+
+def _do_install_dependency(logger, project, dependency, upgrade, force_reinstall, target_dir, log_file):
+    batch = isinstance(dependency, collections.Iterable)
 
     pip_command_line = list()
     pip_command_line.extend(PIP_EXEC_STANZA)
     pip_command_line.append("install")
     pip_command_line.extend(build_pip_install_options(project.get_property("install_dependencies_index_url"),
                                                       project.get_property("install_dependencies_extra_index_url"),
-                                                      project.get_property("install_dependencies_upgrade"),
+                                                      upgrade,
                                                       project.get_property(
                                                           "install_dependencies_insecure_installation"),
-                                                      True if url else False,
+                                                      force_reinstall,
                                                       target_dir,
                                                       project.get_property("verbose"),
                                                       project.get_property("install_dependencies_trusted_host")
@@ -121,10 +197,41 @@ def install_dependency(logger, project, dependency):
     exit_code = execute_command(pip_command_line, log_file, env=os.environ, shell=False)
 
     if exit_code != 0:
+        if batch:
+            dependency_name = " batch dependencies."
+        else:
+            dependency_name = " dependency '%s'." % dependency.name
+
         if project.get_property("verbose"):
             print_file_content(log_file)
-            raise BuildFailedException("Unable to install dependency '%s'.", dependency.name)
+            raise BuildFailedException("Unable to install%s" % dependency_name)
         else:
-            raise BuildFailedException("Unable to install dependency '%s'. See %s for details.",
-                                       getattr(dependency, "name", dependency),
+            raise BuildFailedException("Unable to install%s See %s for details.",
+                                       dependency_name,
                                        log_file)
+
+
+def __reload_pip_if_updated(logger, dependencies_to_install):
+    reload_pip = False
+    for dependency in dependencies_to_install:
+        if dependency.name == "pip":
+            reload_pip = True
+            break
+
+    if reload_pip:
+        __reload_pip(logger)
+
+
+def __reload_pip(logger):
+    logger.debug("Reloading PIP-related modules")
+    modules_to_unload = []
+    for module_name in sys.modules:
+        if module_name.startswith("pip.") or module_name == "pip":
+            modules_to_unload.append(module_name)
+
+    for module_name in modules_to_unload:
+        del sys.modules[module_name]
+
+    from pybuilder import pip_utils, pip_common
+    imp.reload(pip_common)
+    imp.reload(pip_utils)

--- a/src/main/python/pybuilder/reactor.py
+++ b/src/main/python/pybuilder/reactor.py
@@ -51,6 +51,10 @@ class Reactor(object):
     def current_instance():
         return Reactor._current_instance
 
+    @staticmethod
+    def _set_current_instance(reactor):
+        Reactor._current_instance = reactor
+
     def __init__(self, logger, execution_manager, plugin_loader=None):
         self.logger = logger
         self.execution_manager = execution_manager
@@ -92,7 +96,7 @@ class Reactor(object):
                       exclude_all_optional=False):
         if not property_overrides:
             property_overrides = {}
-        Reactor._current_instance = self
+        Reactor._set_current_instance(self)
 
         project_directory, project_descriptor = self.verify_project_directory(
             project_directory, project_descriptor)
@@ -124,7 +128,7 @@ class Reactor(object):
         self.build_execution_plan(tasks, execution_plan)
 
     def create_execution_plan(self, tasks, environments):
-        Reactor._current_instance = self
+        Reactor._set_current_instance(self)
 
         if environments:
             self.logger.info(

--- a/src/unittest/python/ci_server_interaction_tests.py
+++ b/src/unittest/python/ci_server_interaction_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 import unittest
-from mock import patch, call
+from test_utils import patch, call
 
 from pybuilder.core import Project
 from pybuilder.ci_server_interaction import (test_proxy_for,

--- a/src/unittest/python/external_command_tests.py
+++ b/src/unittest/python/external_command_tests.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import Mock, patch, call
+from test_utils import Mock, patch, call
 
 from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
 from pybuilder.core import Project

--- a/src/unittest/python/pip_utils_tests.py
+++ b/src/unittest/python/pip_utils_tests.py
@@ -19,7 +19,7 @@
 import os
 import unittest
 
-from mock import patch, ANY
+from test_utils import patch, ANY
 
 from pybuilder import core
 from pybuilder import pip_utils
@@ -30,9 +30,8 @@ class PipVersionTests(unittest.TestCase):
         self.assertEquals(pip_utils.build_dependency_version_string(core.Dependency("test", "1.2.3")), ">=1.2.3")
         self.assertEquals(pip_utils.build_dependency_version_string(core.Dependency("test", ">=1.2.3,<=2.3.4")),
                           "<=2.3.4,>=1.2.3")
-        self.assertEquals(pip_utils.build_dependency_version_string("1.2.3"), ">=1.2.3")
-        self.assertEquals(pip_utils.build_dependency_version_string(">=1.2.3,<=2.3.4"), "<=2.3.4,>=1.2.3")
-        self.assertRaises(ValueError, pip_utils.build_dependency_version_string, "bogus")
+        self.assertEquals(pip_utils.build_dependency_version_string("1.2.3"), "1.2.3")
+        self.assertEquals(pip_utils.build_dependency_version_string(None), "")
 
     def test_version_satisfies_spec(self):
         self.assertEquals(pip_utils.version_satisfies_spec(None, "blah"), True)

--- a/src/unittest/python/pluginloader_tests.py
+++ b/src/unittest/python/pluginloader_tests.py
@@ -27,7 +27,7 @@ except ImportError as e:
 
     builtin_module = builtins
 
-from mock import patch, Mock, ANY
+from test_utils import patch, Mock, ANY
 from pybuilder.pip_utils import PIP_EXEC_STANZA
 from pybuilder.errors import MissingPluginException, IncompatiblePluginException, UnspecifiedPluginNameException
 from pybuilder.pluginloader import (BuiltinPluginLoader,
@@ -220,9 +220,10 @@ class InstallExternalPluginTests(unittest.TestCase):
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_install_plugin(self, execute, _, read_file):
+    def test_should_install_plugin(self, execute, tempfile, read_file):
         read_file.return_value = ["no problems", "so far"]
         execute.return_value = 0
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         _install_external_plugin(Mock(), "pypi:some-plugin", None, Mock(), None)
 
@@ -233,9 +234,10 @@ class InstallExternalPluginTests(unittest.TestCase):
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_install_plugin_with_version(self, execute, _, read_file):
+    def test_should_install_plugin_with_version(self, execute, tempfile, read_file):
         read_file.return_value = ["no problems", "so far"]
         execute.return_value = 0
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         _install_external_plugin(Mock(), "pypi:some-plugin", "===1.2.3", Mock(), None)
 
@@ -247,9 +249,10 @@ class InstallExternalPluginTests(unittest.TestCase):
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_install_plugin_with_vcs(self, execute, _, read_file):
+    def test_should_install_plugin_with_vcs(self, execute, tempfile, read_file):
         read_file.return_value = ["no problems", "so far"]
         execute.return_value = 0
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         _install_external_plugin(Mock(), "vcs:some-plugin URL", None, Mock(), None)
 
@@ -261,9 +264,10 @@ class InstallExternalPluginTests(unittest.TestCase):
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_install_plugin_with_vcs_and_version(self, execute, _, read_file):
+    def test_should_install_plugin_with_vcs_and_version(self, execute, tempfile, read_file):
         read_file.return_value = ["no problems", "so far"]
         execute.return_value = 0
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         _install_external_plugin(Mock(), "vcs:some-plugin URL", "===1.2.3", Mock(), None)
 
@@ -275,18 +279,20 @@ class InstallExternalPluginTests(unittest.TestCase):
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_raise_error_when_install_from_pypi_fails(self, execute, _, read_file):
+    def test_should_raise_error_when_install_from_pypi_fails(self, execute, tempfile, read_file):
         read_file.return_value = ["something", "went wrong"]
         execute.return_value = 1
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         self.assertRaises(MissingPluginException, _install_external_plugin, Mock(), "pypi:some-plugin", None, Mock(), None)
 
     @patch("pybuilder.pluginloader.read_file")
     @patch("pybuilder.pluginloader.tempfile")
     @patch("pybuilder.pip_utils.execute_command")
-    def test_should_raise_error_when_install_from_vcs_fails(self, execute, _, read_file):
+    def test_should_raise_error_when_install_from_vcs_fails(self, execute, tempfile, read_file):
         read_file.return_value = ["something", "went wrong"]
         execute.return_value = 1
+        tempfile.NamedTemporaryFile().__enter__().name.__eq__.return_value = True
 
         self.assertRaises(MissingPluginException, _install_external_plugin, Mock(), "vcs:some VCS URL", None, Mock(), None)
 

--- a/src/unittest/python/plugins/exec_plugin_tests.py
+++ b/src/unittest/python/plugins/exec_plugin_tests.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 from logging import Logger
-from mock import Mock, patch
+from test_utils import Mock, patch
 
 from pybuilder.core import Project
 from pybuilder.plugins.exec_plugin import run_unit_tests, run_integration_tests, analyze, package, publish

--- a/src/unittest/python/plugins/filter_resources_plugin_tests.py
+++ b/src/unittest/python/plugins/filter_resources_plugin_tests.py
@@ -16,39 +16,39 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from fluentmock import UnitTests, when, verify, NEVER
-from mock import Mock
+import unittest
 
 from pybuilder.core import Project
 from pybuilder.plugins.filter_resources_plugin import ProjectDictWrapper
+from test_utils import Mock
 
 
-class ProjectDictWrapperTest(UnitTests):
-
+class ProjectDictWrapperTest(unittest.TestCase):
     def test_should_return_project_property_when_property_is_defined(self):
         project_mock = Mock(Project)
         project_mock.name = "my name"
 
         self.assertEquals("my name", ProjectDictWrapper(project_mock, Mock())["name"])
 
-        verify(project_mock, NEVER).get_property("name", "name")
+        project_mock.get_property.assert_not_called()
 
     def test_should_delegate_to_project_get_property_when_attribute_is_not_defined(self):
         project_mock = Project(".")
-        when(project_mock).has_property("spam").then_return(True)
-        when(project_mock).get_property("spam").then_return("eggs")
+        project_mock.has_property = Mock(return_value=True)
+        project_mock.get_property = Mock(return_value="eggs")
 
         self.assertEquals("eggs", ProjectDictWrapper(project_mock, Mock())["spam"])
 
-        verify(project_mock).get_property("spam")
+        project_mock.get_property.assert_called_with("spam")
 
     def test_should_warn_when_substitution_is_skipped(self):
         project_mock = Project(".")
         logger_mock = Mock()
-        when(project_mock).has_property("n/a").then_return(False)
+        project_mock.has_property = Mock(return_value=False)
+        project_mock.get_property = Mock()
 
         self.assertEquals("${n/a}", ProjectDictWrapper(project_mock, logger_mock)["n/a"])
 
-        verify(project_mock, NEVER).get_property("n/a")
-        verify(logger_mock).warn(
+        project_mock.get_property.assert_not_called()
+        logger_mock.warn.assert_called_with(
             "Skipping impossible substitution for 'n/a' - there is no matching project attribute or property.")

--- a/src/unittest/python/plugins/python/core_plugin_tests.py
+++ b/src/unittest/python/plugins/python/core_plugin_tests.py
@@ -19,7 +19,7 @@
 import unittest
 from os.path import join
 
-from mock import patch
+from test_utils import patch
 
 from pybuilder.plugins.python.core_plugin import init_python_directories
 from pybuilder.plugins.python.core_plugin import (DISTRIBUTION_PROPERTY,

--- a/src/unittest/python/plugins/python/coverage_plugin_tests.py
+++ b/src/unittest/python/plugins/python/coverage_plugin_tests.py
@@ -19,7 +19,7 @@
 import sys
 from unittest import TestCase
 
-from mock import patch, MagicMock, Mock
+from test_utils import patch, MagicMock, Mock
 
 from pybuilder.core import Project, Logger
 from pybuilder.plugins.python.coverage_plugin import (init_coverage_properties,

--- a/src/unittest/python/plugins/python/cram_plugin_tests.py
+++ b/src/unittest/python/plugins/python/cram_plugin_tests.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import patch, Mock, call
+from test_utils import patch, Mock, call
 
 from pybuilder.core import Project
 from pybuilder.errors import BuildFailedException

--- a/src/unittest/python/plugins/python/distutils_plugin_tests.py
+++ b/src/unittest/python/plugins/python/distutils_plugin_tests.py
@@ -25,7 +25,7 @@ except NameError:
 
 import unittest
 
-from mock import patch, MagicMock, ANY
+from test_utils import patch, MagicMock, ANY
 
 from pybuilder.core import Project, Author, Logger
 from pybuilder.errors import BuildFailedException

--- a/src/unittest/python/plugins/python/flake8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/flake8_plugin_tests.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from pybuilder.core import Project
-from mock import Mock
+from test_utils import Mock
 from pybuilder.plugins.python.flake8_plugin import initialize_flake8_plugin
 
 

--- a/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
+++ b/src/unittest/python/plugins/python/install_dependencies_plugin_tests.py
@@ -19,9 +19,6 @@
 
 import unittest
 
-from mockito import mock, when, verify, unstub, any as any_value
-
-import pybuilder.plugins.python.install_dependencies_plugin
 from pybuilder.core import (Project,
                             Logger,
                             Dependency,
@@ -32,6 +29,7 @@ from pybuilder.plugins.python.install_dependencies_plugin import (initialize_ins
                                                                   install_build_dependencies,
                                                                   install_dependencies,
                                                                   install_dependency)
+from test_utils import Mock, ANY, patch
 
 __author__ = "Alexander Metzner"
 
@@ -40,173 +38,189 @@ class InstallDependencyTest(unittest.TestCase):
     def setUp(self):
         self.project = Project("unittest", ".")
         self.project.set_property("dir_install_logs", "any_directory")
-        self.logger = mock(Logger)
+        self.logger = Mock(Logger)
         initialize_install_dependencies_plugin(self.project)
-        when(pybuilder.plugins.python.install_dependencies_plugin).execute_command(any_value(),
-                                                                                   any_value(),
-                                                                                   env=any_value(),
-                                                                                   shell=False).thenReturn(0)
 
-    def tearDown(self):
-        unstub()
-
-    def test_should_install_dependency_without_version(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_without_version(self, exec_command, get_package_version):
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
+        exec_command.assert_called_with(PIP_EXEC_STANZA + ["install", '--upgrade', 'spam'], ANY, env=ANY, shell=False)
 
-    def test_should_install_requirements_file_dependency(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_requirements_file_dependency(self, exec_command, get_package_version):
         dependency = RequirementsFile("requirements.txt")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", '-r', "requirements.txt"], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", '-r', "requirements.txt"], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_without_version_on_windows_derivate(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_without_version_on_windows_derivate(self, exec_command, get_package_version):
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "spam"], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "spam"], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_insecurely_when_property_is_set(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.pip_utils._pip_disallows_insecure_packages_by_default", return_value=True)
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_insecurely_when_property_is_set(self, exec_command, _, get_package_version):
         dependency = Dependency("spam")
         self.project.set_property("install_dependencies_insecure_installation", ["spam"])
-        when(pybuilder.pip_utils)._pip_disallows_insecure_packages_by_default().thenReturn(True)
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
+        exec_command(
             PIP_EXEC_STANZA + ["install", "--allow-unverified", "spam", "--allow-external", "spam", 'spam'],
-            any_value(), env=any_value(), shell=False)
+            ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_securely_when_property_is_not_set_to_dependency(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.pip_utils._pip_disallows_insecure_packages_by_default", return_value=True)
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_securely_when_property_is_not_set_to_dependency(self, exec_command, _,
+                                                                                       get_package_version):
         dependency = Dependency("spam")
         self.project.set_property("install_dependencies_insecure_installation", ["some-other-dependency"])
-        when(pybuilder.pip_utils)._pip_disallows_insecure_packages_by_default().thenReturn(True)
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
+        exec_command(
             PIP_EXEC_STANZA + ["install", "--allow-unverified", "some-other-dependency", "--allow-external",
-                               "some-other-dependency", 'spam'], any_value(), env=any_value(), shell=False)
+                               "some-other-dependency", 'spam'], ANY, env=ANY, shell=False)
         #  some-other-dependency might be a dependency of 'spam'
         #  so we always have to put the insecure dependencies in the command line :-(
 
-    def test_should_not_use_insecure_flags_when_pip_version_is_too_low(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.pip_utils._pip_disallows_insecure_packages_by_default", return_value=False)
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_not_use_insecure_flags_when_pip_version_is_too_low(self, exec_command, _, get_package_version):
         dependency = Dependency("spam")
         self.project.set_property("install_dependencies_insecure_installation", ["spam"])
-        when(pybuilder.pip_utils)._pip_disallows_insecure_packages_by_default().thenReturn(False)
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", 'spam'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", 'spam'], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_using_custom_index_url(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_using_custom_index_url(self, exec_command, get_package_version):
         self.project.set_property("install_dependencies_index_url", "some_index_url")
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", 'spam'], any_value(), env=any_value(),
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", 'spam'], ANY, env=ANY,
             shell=False)
 
-    def test_should_use_extra_index_url_when_index_url_is_not_set(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_use_extra_index_url_when_index_url_is_not_set(self, exec_command, get_package_version):
         self.project.set_property("install_dependencies_extra_index_url", "some_extra_index_url")
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "--extra-index-url", "some_extra_index_url", 'spam'], any_value(),
-            env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "--extra-index-url", "some_extra_index_url", 'spam'], ANY,
+            env=ANY, shell=False)
 
-    def test_should_use_index_and_extra_index_url_when_index_and_extra_index_url_are_set(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_use_index_and_extra_index_url_when_index_and_extra_index_url_are_set(self, exec_command,
+                                                                                         get_package_version):
         self.project.set_property("install_dependencies_index_url", "some_index_url")
         self.project.set_property("install_dependencies_extra_index_url", "some_extra_index_url")
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
+        exec_command(
             PIP_EXEC_STANZA + ["install", "--index-url", "some_index_url", "--extra-index-url",
-                               "some_extra_index_url", 'spam'], any_value(), env=any_value(), shell=False)
+                               "some_extra_index_url", 'spam'], ANY, env=ANY, shell=False)
 
-    def test_should_upgrade_dependencies(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_upgrade_dependencies(self, exec_command, get_package_version):
         self.project.set_property("install_dependencies_upgrade", True)
         dependency = Dependency("spam")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "--upgrade", 'spam'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "--upgrade", 'spam'], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_with_version(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_with_version(self, exec_command, get_package_version):
         dependency = Dependency("spam", "0.1.2")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", 'spam>=0.1.2'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", 'spam>=0.1.2'], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_with_version_and_operator(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_with_version_and_operator(self, exec_command, get_package_version):
         dependency = Dependency("spam", "==0.1.2")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", 'spam==0.1.2'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", 'spam==0.1.2'], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_with_url(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_with_url(self, exec_command, get_package_version):
         dependency = Dependency("spam", url="some_url")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], ANY, env=ANY, shell=False)
 
-    def test_should_install_dependency_with_url_even_if_version_is_given(self):
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.get_package_version", return_value={})
+    @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+    def test_should_install_dependency_with_url_even_if_version_is_given(self, exec_command, get_package_version):
         dependency = Dependency("spam", version="0.1.2", url="some_url")
 
         install_dependency(self.logger, self.project, dependency)
 
-        verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], any_value(), env=any_value(), shell=False)
+        exec_command(
+            PIP_EXEC_STANZA + ["install", "--force-reinstall", 'some_url'], ANY, env=ANY, shell=False)
 
     class InstallRuntimeDependenciesTest(unittest.TestCase):
         def setUp(self):
             self.project = Project("unittest", ".")
             self.project.set_property("dir_install_logs", "any_directory")
-            self.logger = mock(Logger)
+            self.logger = Mock(Logger)
             initialize_install_dependencies_plugin(self.project)
-            when(pybuilder.plugins.python.install_dependencies_plugin).execute_command(any_value(), any_value(),
-                                                                                       shell=False).thenReturn(0)
 
-        def tearDown(self):
-            unstub()
-
-        def test_should_install_multiple_dependencies(self):
+        @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+        def test_should_install_multiple_dependencies(self, exec_command, get_package_version):
             self.project.depends_on("spam")
             self.project.depends_on("eggs")
             self.project.depends_on_requirements("requirements.txt")
 
             install_runtime_dependencies(self.logger, self.project)
 
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", 'spam'], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", 'eggs'], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", '-r', 'requirements.txt'], any_value(), shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", 'spam'], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", 'eggs'], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", '-r', 'requirements.txt'], ANY, shell=False)
 
-        def test_should_install_multiple_dependencies_locally(self):
+        @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+        def test_should_install_multiple_dependencies_locally(self, exec_command, get_package_version):
             self.project.depends_on("spam")
             self.project.depends_on("eggs")
             self.project.depends_on("foo")
@@ -217,62 +231,42 @@ class InstallDependencyTest(unittest.TestCase):
 
             install_runtime_dependencies(self.logger, self.project)
 
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", "-t", "any-dir", 'spam'], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", "-t", "any-other-dir", 'eggs'], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", 'foo'], any_value(), shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", "-t", "any-dir", 'spam'], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", "-t", "any-other-dir", 'eggs'], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", 'foo'], ANY, shell=False)
 
     class InstallBuildDependenciesTest(unittest.TestCase):
         def setUp(self):
             self.project = Project("unittest", ".")
             self.project.set_property("dir_install_logs", "any_directory")
-            self.logger = mock(Logger)
+            self.logger = Mock(Logger)
             initialize_install_dependencies_plugin(self.project)
-            when(pybuilder.plugins.python.install_dependencies_plugin).execute_command(any_value(),
-                                                                                       any_value(),
-                                                                                       env=any_value(),
-                                                                                       shell=False).thenReturn(0)
 
-        def tearDown(self):
-            unstub()
-
-        def test_should_install_multiple_dependencies(self):
+        @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+        def test_should_install_multiple_dependencies(self, exec_command, get_package_version):
             self.project.build_depends_on("spam")
             self.project.build_depends_on("eggs")
             self.project.build_depends_on_requirements("requirements-dev.txt")
 
             install_build_dependencies(self.logger, self.project)
 
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", "spam"], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", "eggs"], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", '-r', 'requirements-dev.txt'], any_value(), shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", "spam"], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", "eggs"], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", '-r', 'requirements-dev.txt'], ANY, shell=False)
 
     class InstallDependenciesTest(unittest.TestCase):
         def setUp(self):
             self.project = Project("unittest", ".")
             self.project.set_property("dir_install_logs", "any_directory")
-            self.logger = mock(Logger)
+            self.logger = Mock(Logger)
             initialize_install_dependencies_plugin(self.project)
-            when(pybuilder.plugins.python.install_dependencies_plugin).execute_command(any_value(),
-                                                                                       any_value(),
-                                                                                       env=any_value(),
-                                                                                       shell=False).thenReturn(0)
 
-        def tearDown(self):
-            unstub()
-
-        def test_should_install_single_dependency_without_version(self):
+        @patch("pybuilder.plugins.python.install_dependencies_plugin.execute_command", return_value=0)
+        def test_should_install_single_dependency_without_version(self, exec_command, get_package_version):
             self.project.depends_on("spam")
             self.project.build_depends_on("eggs")
 
             install_dependencies(self.logger, self.project)
 
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", 'spam'], any_value(), shell=False)
-            verify(pybuilder.plugins.python.install_dependencies_plugin).execute_command(
-                PIP_EXEC_STANZA + ["install", 'eggs'], any_value(), shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", 'spam'], ANY, shell=False)
+            exec_command(PIP_EXEC_STANZA + ["install", 'eggs'], ANY, shell=False)

--- a/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from Queue import Empty
 
-from mock import patch
+from test_utils import patch
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.integrationtest_plugin import (

--- a/src/unittest/python/plugins/python/pep8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pep8_plugin_tests.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 from pybuilder.core import Project
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 
 from pybuilder.plugins.python.pep8_plugin import (

--- a/src/unittest/python/plugins/python/pycharm_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pycharm_plugin_tests.py
@@ -23,7 +23,7 @@ except NameError:
 
 
 import unittest
-from mock import patch, Mock, MagicMock
+from test_utils import patch, Mock, MagicMock
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.pycharm_plugin import (

--- a/src/unittest/python/plugins/python/pychecker_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pychecker_plugin_tests.py
@@ -18,16 +18,14 @@
 
 import unittest
 
-from mockito import mock, when
-
 from pybuilder.plugins.python.pychecker_plugin import (PycheckerModuleReport,
                                                        PycheckerWarning,
                                                        PycheckerReport,
                                                        parse_pychecker_output)
+from test_utils import Mock
 
 
-class PycheckerWarningTest (unittest.TestCase):
-
+class PycheckerWarningTest(unittest.TestCase):
     def test_to_json_dict(self):
         expected = {
             "message": "any message",
@@ -37,8 +35,7 @@ class PycheckerWarningTest (unittest.TestCase):
             expected, PycheckerWarning("any message", 17).to_json_dict())
 
 
-class PycheckerModuleReportTest (unittest.TestCase):
-
+class PycheckerModuleReportTest(unittest.TestCase):
     def test_to_json_dict(self):
         report = PycheckerModuleReport("any.module")
         report.add_warning(PycheckerWarning("warning 1", 1))
@@ -52,10 +49,8 @@ class PycheckerModuleReportTest (unittest.TestCase):
         self.assertEquals(expected, report.to_json_dict())
 
 
-class PycheckerReportTest (unittest.TestCase):
-
+class PycheckerReportTest(unittest.TestCase):
     def test_to_json_dict(self):
-
         module_report_one = PycheckerModuleReport("any.module")
         module_report_one.add_warning(PycheckerWarning("warning 1", 1))
         module_report_one.add_warning(PycheckerWarning("warning 2", 2))
@@ -86,12 +81,10 @@ class PycheckerReportTest (unittest.TestCase):
         self.assertEquals(expected, report.to_json_dict())
 
 
-class ParsePycheckerOutputTest (unittest.TestCase):
-
+class ParsePycheckerOutputTest(unittest.TestCase):
     def test_should_parse_report(self):
-        project = mock()
-        when(project).expand_path(
-            "$dir_source_main_python").thenReturn("/path/to")
+        project = Mock()
+        project.expand_path.return_value = "/path/to"
 
         warnings = [
             "/path/to/package/module_one:2: Sample warning",

--- a/src/unittest/python/plugins/python/pydev_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pydev_plugin_tests.py
@@ -23,7 +23,7 @@ except NameError:
 
 
 import unittest
-from mock import patch, Mock, MagicMock, call
+from test_utils import patch, Mock, MagicMock, call
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.pydev_plugin import (

--- a/src/unittest/python/plugins/python/pyfix_plugin_impl_tests.py
+++ b/src/unittest/python/plugins/python/pyfix_plugin_impl_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 
 from pybuilder.plugins.python.pyfix_plugin_impl import TestListener

--- a/src/unittest/python/plugins/python/pyfix_unittest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pyfix_unittest_plugin_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from mock import Mock, call, patch
+from test_utils import Mock, call, patch
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.pyfix_unittest_plugin import init_test_source_directory

--- a/src/unittest/python/plugins/python/pylint_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pylint_plugin_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 
 from pybuilder.core import Project

--- a/src/unittest/python/plugins/python/pymetrics_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pymetrics_plugin_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 
 from pybuilder.plugins.python.pymetrics_plugin import check_pymetrics_available

--- a/src/unittest/python/plugins/python/pytddmon_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pytddmon_plugin_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 import unittest
-from mock import Mock, patch, ANY
+from test_utils import Mock, patch, ANY
 
 from pybuilder.core import Project
 from pybuilder.plugins.python import pytddmon_plugin

--- a/src/unittest/python/plugins/python/python_plugin_helper_tests.py
+++ b/src/unittest/python/plugins/python/python_plugin_helper_tests.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import Mock, call, patch
+from test_utils import Mock, call, patch
 
 from pybuilder.plugins.python.python_plugin_helper import (log_report,
                                                            discover_affected_files,

--- a/src/unittest/python/plugins/python/snakefood_plugin_tests.py
+++ b/src/unittest/python/plugins/python/snakefood_plugin_tests.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 from pybuilder.core import Project
 from pybuilder.plugins.python.snakefood_plugin import (

--- a/src/unittest/python/plugins/python/sonarqube_plugin_tests.py
+++ b/src/unittest/python/plugins/python/sonarqube_plugin_tests.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 
-from mock import Mock, patch
+from test_utils import Mock, patch
 
 from pybuilder.core import Project
 from pybuilder.errors import BuildFailedException

--- a/src/unittest/python/plugins/python/sphinx_plugin_tests.py
+++ b/src/unittest/python/plugins/python/sphinx_plugin_tests.py
@@ -19,8 +19,6 @@
 from logging import Logger
 from unittest import TestCase
 
-from mock import Mock, patch
-
 from pybuilder.core import Project, Author
 from pybuilder.plugins.python.sphinx_plugin import (
     assert_sphinx_is_available,
@@ -29,6 +27,7 @@ from pybuilder.plugins.python.sphinx_plugin import (
     get_sphinx_quickstart_command,
     initialize_sphinx_plugin,
     run_sphinx_build)
+from test_utils import Mock, patch
 
 
 class CheckSphinxAvailableTests(TestCase):

--- a/src/unittest/python/plugins/python/stdeb_plugin_tests.py
+++ b/src/unittest/python/plugins/python/stdeb_plugin_tests.py
@@ -17,7 +17,7 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from mock import Mock, patch
+from test_utils import Mock, patch
 from pybuilder.core import Project
 from logging import Logger
 from pybuilder.plugins.python.stdeb_plugin import (

--- a/src/unittest/python/plugins/python/test_plugin_helper_tests.py
+++ b/src/unittest/python/plugins/python/test_plugin_helper_tests.py
@@ -17,42 +17,34 @@
 #   limitations under the License.
 
 import unittest
-from mockito import mock, unstub, any, verify, when
 
-import pybuilder
-from pybuilder.plugins.python.test_plugin_helper import ReportsProcessor
 from pybuilder.errors import BuildFailedException
+from pybuilder.plugins.python.test_plugin_helper import ReportsProcessor
+from test_utils import Mock, patch
 
 
 class ReportsProcessorTests(unittest.TestCase):
-
     def setUp(self):
-        self.reports_processor = ReportsProcessor(mock(), mock())
-        self.reports_processor.process_reports([], mock())
-
-    def tearDown(self):
-        unstub()
+        self.reports_processor = ReportsProcessor(Mock(), Mock())
+        total_time = Mock()
+        total_time.get_millis.return_value = 42
+        self.reports_processor.process_reports([], total_time)
 
     def test_should_raise_exception_when_not_all_tests_pass(self):
-
         self.reports_processor.tests_failed = 1
 
-        self.assertRaises(
-            BuildFailedException, self.reports_processor.write_report_and_ensure_all_tests_passed)
+        self.assertRaises(BuildFailedException, self.reports_processor.write_report_and_ensure_all_tests_passed)
 
     def test_should_not_raise_exception_when_all_tests_pass(self):
         self.reports_processor.tests_failed = 0
 
         self.reports_processor.write_report_and_ensure_all_tests_passed()
 
-    def test_should_write_report(self):
-        when(pybuilder.plugins.python.test_plugin_helper).render_report(
-            any()).thenReturn('rendered-report')
-
+    @patch("pybuilder.plugins.python.test_plugin_helper.render_report", return_value='rendered-report')
+    def test_should_write_report(self, render_report):
         self.reports_processor.write_report_and_ensure_all_tests_passed()
 
-        verify(self.reports_processor.project).write_report(
-            "integrationtest.json", 'rendered-report')
+        self.reports_processor.project.write_report.assert_called_with("integrationtest.json", 'rendered-report')
 
     def test_should_parse_reports(self):
         reports = [
@@ -64,14 +56,14 @@ class ReportsProcessorTests(unittest.TestCase):
                 'file3', 'success': True, 'time': 3},
             {'test': 'name4', 'test_file': 'file4', 'success': True, 'time': 4}
         ]
-        self.reports_processor.process_reports(reports, mock())
+        self.reports_processor.process_reports(reports, Mock())
 
         self.assertEqual(self.reports_processor.tests_failed, 2)
         self.assertEqual(self.reports_processor.tests_executed, 4)
 
     def test_should_create_test_report_with_attributes(self):
-        mock_time = mock()
-        when(mock_time).get_millis().thenReturn(42)
+        mock_time = Mock()
+        mock_time.get_millis.return_value = 42
 
         self.reports_processor.process_reports([], mock_time)
         self.reports_processor.tests_failed = 4

--- a/src/unittest/python/plugins/python/unittest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/unittest_plugin_tests.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 
 from unittest import TestCase, TextTestRunner
 
-from mock import Mock, patch
+from test_utils import Mock, patch
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.unittest_plugin import (execute_tests, execute_tests_matching,

--- a/src/unittest/python/plugins/ronn_manpage_plugin_tests.py
+++ b/src/unittest/python/plugins/ronn_manpage_plugin_tests.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 from pybuilder.core import Project
-from mock import Mock, patch
+from test_utils import Mock, patch
 from logging import Logger
 from pybuilder.plugins.ronn_manpage_plugin import (
     build_generate_manpages_command,

--- a/src/unittest/python/reactor_tests.py
+++ b/src/unittest/python/reactor_tests.py
@@ -16,12 +16,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import imp
 import unittest
-
-import os
-from mockito import when, verify, unstub, any, times, contains, inorder
-from mockito.matchers import Matcher
+from types import ModuleType
 
 from pybuilder.core import (ENVIRONMENTS_ATTRIBUTE,
                             INITIALIZER_ATTRIBUTE,
@@ -35,48 +31,35 @@ from pybuilder.core import (ENVIRONMENTS_ATTRIBUTE,
                             after,
                             before)
 from pybuilder.errors import MissingPluginException, PyBuilderException, ProjectValidationFailedException
-from pybuilder.execution import Task, TaskDependency, Action, Initializer, ExecutionManager
+from pybuilder.execution import Task, TaskDependency, Action, ExecutionManager, Initializer
 from pybuilder.pluginloader import PluginLoader
 from pybuilder.reactor import Reactor
-from test_utils import mock  # TODO @mriehl SORCERY!!!!! BURN IT WITH FIRE!!!!
-
-
-class TaskNameMatcher(Matcher):
-    def __init__(self, task_name):
-        self.task_name = task_name
-
-    def matches(self, arg):
-        if not isinstance(arg, Task):
-            return False
-        return arg.name == self.task_name
-
-    def repr(self):
-        return "Task with name %s" % self.task_name
+from test_utils import Mock, ANY, call, patch
 
 
 class ReactorTest(unittest.TestCase):
     def setUp(self):
-        self.plugin_loader_mock = mock(PluginLoader)
-        self.logger = mock()
-        self.execution_manager = mock(ExecutionManager)
+        self.old_reactor = Reactor.current_instance()
+        self.plugin_loader_mock = Mock(PluginLoader)
+        self.logger = Mock()
+        self.execution_manager = Mock(ExecutionManager)
         self.reactor = Reactor(
             self.logger, self.execution_manager, self.plugin_loader_mock)
 
     def tearDown(self):
-        unstub()
+        Reactor._set_current_instance(self.old_reactor)
 
     def test_should_return_tasks_from_execution_manager_when_calling_get_tasks(self):
         self.execution_manager.tasks = ["spam"]
         self.assertEquals(["spam"], self.reactor.get_tasks())
 
     def test_should_raise_exception_when_importing_plugin_and_plugin_not_found(self):
-        when(self.plugin_loader_mock).load_plugin(
-            any(), "not_found", any(), any()).thenRaise(MissingPluginException("not_found"))
+        self.plugin_loader_mock.load_plugin.side_effect = MissingPluginException("not_found")
 
         self.assertRaises(
             MissingPluginException, self.reactor.import_plugin, "not_found")
 
-        verify(self.plugin_loader_mock).load_plugin(any(), "not_found", None, None)
+        self.plugin_loader_mock.load_plugin.assert_called_with(ANY, "not_found", None, None)
 
     def test_should_collect_single_task(self):
         def task():
@@ -84,12 +67,15 @@ class ReactorTest(unittest.TestCase):
 
         setattr(task, TASK_ATTRIBUTE, True)
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = task
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager).register_task(TaskNameMatcher("task"))
+        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 1)
+        self.assertTrue(isinstance(self.execution_manager.register_task.call_args[0][0], Task) and len(
+            self.execution_manager.register_task.call_args[0]) == 1)
+        self.assertEquals(self.execution_manager.register_task.call_args[0][0].name, "task")
 
     def test_should_collect_single_task_with_overridden_name(self):
         def task():
@@ -98,13 +84,15 @@ class ReactorTest(unittest.TestCase):
         setattr(task, TASK_ATTRIBUTE, True)
         setattr(task, NAME_ATTRIBUTE, "overridden_name")
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = task
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager).register_task(
-            TaskNameMatcher("overridden_name"))
+        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 1)
+        self.assertTrue(isinstance(self.execution_manager.register_task.call_args[0][0], Task) and len(
+            self.execution_manager.register_task.call_args[0]) == 1)
+        self.assertEquals(self.execution_manager.register_task.call_args[0][0].name, "overridden_name")
 
     def test_should_collect_multiple_tasks(self):
         def task():
@@ -117,96 +105,102 @@ class ReactorTest(unittest.TestCase):
 
         setattr(task2, TASK_ATTRIBUTE, True)
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = task
         module.task2 = task2
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager, times(2)).register_task(any(Task))
+        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 2)
+        for call_args in self.execution_manager.register_task.call_args_list:
+            self.assertTrue(isinstance(call_args[0][0], Task) and len(call_args[0]) == 1)
 
     def test_task_dependencies(self):
         import pybuilder.reactor
 
-        when(pybuilder.reactor).Task().thenReturn(mock())
+        with patch("pybuilder.reactor.Task"):
+            @task
+            def task1():
+                pass
 
-        @task
-        def task1():
-            pass
+            @task
+            @depends(task1)
+            def task2():
+                pass
 
-        @task
-        @depends(task1)
-        def task2():
-            pass
+            @task
+            def task3():
+                pass
 
-        @task
-        def task3():
-            pass
+            @task
+            @depends(optional(task3))
+            @dependents("task6")
+            def task4():
+                pass
 
-        @task
-        @depends(optional(task3))
-        @dependents("task6")
-        def task4():
-            pass
+            @task
+            @dependents("task6", optional(task3))
+            def task5():
+                pass
 
-        @task
-        @dependents("task6", optional(task3))
-        def task5():
-            pass
+            @task
+            @depends(task1, optional(task2))
+            def task6():
+                pass
 
-        @task
-        @depends(task1, optional(task2))
-        def task6():
-            pass
+            module = ModuleType("mock_module")
+            module.task1 = task1
+            module.task2 = task2
+            module.task3 = task3
+            module.task4 = task4
+            module.task5 = task5
+            module.task6 = task6
 
-        module = mock()
-        module.task1 = task1
-        module.task2 = task2
-        module.task3 = task3
-        module.task4 = task4
-        module.task5 = task5
-        module.task6 = task6
+            self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.reactor.collect_tasks_and_actions_and_initializers(module)
-
-        inorder.verify(pybuilder.reactor).Task("task1", task1, [], '')
-        inorder.verify(pybuilder.reactor).Task("task2", task2, [TaskDependency(task1)], '')
-        inorder.verify(pybuilder.reactor).Task("task3", task3, [TaskDependency(task5, True)], '')
-        inorder.verify(pybuilder.reactor).Task("task4", task4, [TaskDependency(task3, True)], '')
-        inorder.verify(pybuilder.reactor).Task("task5", task5, [], '')
-        inorder.verify(pybuilder.reactor).Task("task6", task6, [TaskDependency(task1), TaskDependency(task2, True),
-                                                                TaskDependency(task4), TaskDependency(task5)], '')
+            pybuilder.reactor.Task.assert_has_calls([call("task1", task1, [], ''),
+                                                     call("task2", task2, [TaskDependency(task1)], ''),
+                                                     call("task3", task3, [TaskDependency(task5, True)], ''),
+                                                     call("task4", task4, [TaskDependency(task3, True)], ''),
+                                                     call("task5", task5, [], ''),
+                                                     call("task6", task6,
+                                                          [TaskDependency(task1), TaskDependency(task2, True),
+                                                           TaskDependency(task4), TaskDependency(task5)], '')])
 
     def test_should_collect_single_before_action(self):
         @before("spam")
         def action():
             pass
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = action
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager).register_action(any(Action))
+        self.assertEquals(self.execution_manager.register_action.call_count, 1)
+        self.assertTrue(isinstance(self.execution_manager.register_action.call_args[0][0], Action) and
+                        len(self.execution_manager.register_action.call_args[0]) == 1)
 
     def test_should_collect_single_after_action(self):
         @after("spam")
         def action():
             pass
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = action
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager).register_action(any(Action))
+        self.assertEquals(self.execution_manager.register_action.call_count, 1)
+        self.assertTrue(isinstance(self.execution_manager.register_action.call_args[0][0], Action) and
+                        len(self.execution_manager.register_action.call_args[0]) == 1)
 
     def test_should_collect_single_after_action_with_only_once_flag(self):
         @after("spam", only_once=True)
         def action():
             pass
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = action
 
         def register_action(action):
@@ -222,7 +216,7 @@ class ReactorTest(unittest.TestCase):
         def action():
             pass
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = action
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
@@ -233,12 +227,14 @@ class ReactorTest(unittest.TestCase):
 
         setattr(init, INITIALIZER_ATTRIBUTE, True)
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = init
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        verify(self.execution_manager).register_initializer(any(Initializer))
+        self.assertEquals(self.execution_manager.register_initializer.call_count, 1)
+        self.assertTrue(isinstance(self.execution_manager.register_initializer.call_args[0][0], Initializer) and
+                        len(self.execution_manager.register_initializer.call_args[0]) == 1)
 
     def test_should_collect_single_initializer_with_environments(self):
         def init():
@@ -247,7 +243,7 @@ class ReactorTest(unittest.TestCase):
         setattr(init, INITIALIZER_ATTRIBUTE, True)
         setattr(init, ENVIRONMENTS_ATTRIBUTE, ["any_environment"])
 
-        module = mock()
+        module = ModuleType("mock_module")
         module.task = init
 
         class ExecutionManagerMock(object):
@@ -262,107 +258,114 @@ class ReactorTest(unittest.TestCase):
         self.assertEquals(
             execution_manager_mock.initializer.environments, ["any_environment"])
 
-    def test_should_raise_exception_when_verifying_project_directory_and_directory_does_not_exist(self):
-        when(os.path).abspath("spam").thenReturn("spam")
-        when(os.path).exists("spam").thenReturn(False)
-
+    @patch("pybuilder.reactor.os.path.exists", return_value=False)
+    @patch("pybuilder.reactor.os.path.abspath", return_value="spam")
+    def test_should_raise_when_verifying_project_directory_and_directory_does_not_exist(self,
+                                                                                        os_path_abspath,
+                                                                                        os_path_exists):
         self.assertRaises(
             PyBuilderException, self.reactor.verify_project_directory, "spam", "eggs")
 
-        verify(os.path).abspath("spam")
-        verify(os.path).exists("spam")
+        os_path_abspath.assert_called_with("spam")
+        os_path_exists.assert_called_with("spam")
 
-    def test_should_raise_exception_when_verifying_project_directory_and_directory_is_not_a_directory(self):
-        when(os.path).abspath("spam").thenReturn("spam")
-        when(os.path).exists("spam").thenReturn(True)
-        when(os.path).isdir("spam").thenReturn(False)
-
+    @patch("pybuilder.reactor.os.path.isdir", return_value=False)
+    @patch("pybuilder.reactor.os.path.exists", return_value=True)
+    @patch("pybuilder.reactor.os.path.abspath", return_value="spam")
+    def test_should_raise_when_verifying_project_directory_and_directory_is_not_a_directory(self,
+                                                                                            os_path_abspath,
+                                                                                            os_path_exists,
+                                                                                            os_path_isdir):
         self.assertRaises(
             PyBuilderException, self.reactor.verify_project_directory, "spam", "eggs")
 
-        verify(os.path).abspath("spam")
-        verify(os.path).exists("spam")
-        verify(os.path).isdir("spam")
+        os_path_abspath.assert_called_with("spam")
+        os_path_exists.assert_called_with("spam")
+        os_path_isdir.assert_called_with("spam")
 
-    def test_should_raise_exception_when_verifying_project_directory_and_build_descriptor_does_not_exist(self):
-        when(os.path).abspath("spam").thenReturn("spam")
-        when(os.path).exists("spam").thenReturn(True)
-        when(os.path).isdir("spam").thenReturn(True)
-        when(os.path).join("spam", "eggs").thenReturn("spam/eggs")
-        when(os.path).exists("spam/eggs").thenReturn(False)
-
+    @patch("pybuilder.reactor.os.path.join", side_effect=lambda *x: "/".join(x))
+    @patch("pybuilder.reactor.os.path.isdir", return_value=True)
+    @patch("pybuilder.reactor.os.path.exists", side_effect=lambda x: True if x == "spam" else False)
+    @patch("pybuilder.reactor.os.path.abspath", return_value="spam")
+    def test_should_raise_when_verifying_project_directory_and_build_descriptor_does_not_exist(self,
+                                                                                               os_path_abspath,
+                                                                                               os_path_exists,
+                                                                                               os_path_isdir,
+                                                                                               os_path_join):
         self.assertRaises(
             PyBuilderException, self.reactor.verify_project_directory, "spam", "eggs")
 
-        verify(os.path).abspath("spam")
-        verify(os.path).exists("spam")
-        verify(os.path).isdir("spam")
-        verify(os.path).join("spam", "eggs")
-        verify(os.path).exists("spam/eggs")
+        os_path_abspath.assert_called_with("spam")
+        os_path_exists.assert_has_calls([call("spam"), call("spam/eggs")])
+        os_path_isdir.assert_called_with("spam")
+        os_path_join.assert_called_with("spam", "eggs")
 
-    def test_should_raise_exception_when_verifying_project_directory_and_build_descriptor_is_not_a_file(self):
-        when(os.path).abspath("spam").thenReturn("spam")
-        when(os.path).exists("spam").thenReturn(True)
-        when(os.path).isdir("spam").thenReturn(True)
-        when(os.path).join("spam", "eggs").thenReturn("spam/eggs")
-        when(os.path).exists("spam/eggs").thenReturn(True)
-        when(os.path).isfile("spam/eggs").thenReturn(False)
-
+    @patch("pybuilder.reactor.os.path.isfile", return_value=False)
+    @patch("pybuilder.reactor.os.path.join", side_effect=lambda *x: "/".join(x))
+    @patch("pybuilder.reactor.os.path.isdir", return_value=True)
+    @patch("pybuilder.reactor.os.path.exists", return_value=True)
+    @patch("pybuilder.reactor.os.path.abspath", return_value="spam")
+    def test_should_raise_when_verifying_project_directory_and_build_descriptor_is_not_a_file(self,
+                                                                                              os_path_abspath,
+                                                                                              os_path_exists,
+                                                                                              os_path_isdir,
+                                                                                              os_path_join,
+                                                                                              os_path_isfile):
         self.assertRaises(
             PyBuilderException, self.reactor.verify_project_directory, "spam", "eggs")
 
-        verify(os.path).abspath("spam")
-        verify(os.path).exists("spam")
-        verify(os.path).isdir("spam")
-        verify(os.path).join("spam", "eggs")
-        verify(os.path).exists("spam/eggs")
-        verify(os.path).isfile("spam/eggs")
+        os_path_abspath.assert_called_with("spam")
+        os_path_exists.assert_has_calls([call("spam"), call("spam/eggs")])
+        os_path_isdir.assert_called_with("spam")
+        os_path_join.assert_called_with("spam", "eggs")
+        os_path_isfile.assert_called_with("spam/eggs")
 
-    def test_should_return_directory_and_full_path_of_descriptor_when_verifying_project_directory(self):
-        when(os.path).abspath("spam").thenReturn("/spam")
-        when(os.path).exists("/spam").thenReturn(True)
-        when(os.path).isdir("/spam").thenReturn(True)
-        when(os.path).join("/spam", "eggs").thenReturn("/spam/eggs")
-        when(os.path).exists("/spam/eggs").thenReturn(True)
-        when(os.path).isfile("/spam/eggs").thenReturn(True)
-
+    @patch("pybuilder.reactor.os.path.isfile", return_value=True)
+    @patch("pybuilder.reactor.os.path.join", side_effect=lambda *x: "/".join(x))
+    @patch("pybuilder.reactor.os.path.isdir", return_value=True)
+    @patch("pybuilder.reactor.os.path.exists", return_value=True)
+    @patch("pybuilder.reactor.os.path.abspath", return_value="/spam")
+    def test_should_return_directory_and_full_path_of_descriptor_when_verifying_project_directory(self,
+                                                                                                  os_path_abspath,
+                                                                                                  os_path_exists,
+                                                                                                  os_path_isdir,
+                                                                                                  os_path_join,
+                                                                                                  os_path_isfile):
         self.assertEquals(
             ("/spam", "/spam/eggs"), self.reactor.verify_project_directory("spam", "eggs"))
 
-        verify(os.path).abspath("spam")
-        verify(os.path).exists("/spam")
-        verify(os.path).isdir("/spam")
-        verify(os.path).join("/spam", "eggs")
-        verify(os.path).exists("/spam/eggs")
-        verify(os.path).isfile("/spam/eggs")
+        os_path_abspath.assert_called_with("spam")
+        os_path_exists.assert_has_calls([call("/spam"), call("/spam/eggs")])
+        os_path_isdir.assert_called_with("/spam")
+        os_path_join.assert_called_with("/spam", "eggs")
+        os_path_isfile.assert_called_with("/spam/eggs")
 
-    def test_should_raise_exception_when_loading_project_module_and_import_raises_exception(self):
-        when(imp).load_source("build", "spam").thenRaise(ImportError("spam"))
-
+    @patch("pybuilder.reactor.imp.load_source", side_effect=ImportError("spam"))
+    def test_should_raise_when_loading_project_module_and_import_raises_exception(self, imp_load_source):
         self.assertRaises(
             PyBuilderException, self.reactor.load_project_module, "spam")
 
-        verify(imp).load_source("build", "spam")
+        imp_load_source.assert_called_with("build", "spam")
 
-    def test_should_return_module_when_loading_project_module_and_import_raises_exception(self):
-        module = mock()
-        when(imp).load_source("build", "spam").thenReturn(module)
+    @patch("pybuilder.reactor.imp.load_source", return_value=Mock())
+    def test_should_return_module_when_loading_project_module_and_import_raises_exception(self, imp_load_source):
+        self.assertTrue(imp_load_source.return_value is self.reactor.load_project_module("spam"))
 
-        self.assertEquals(module, self.reactor.load_project_module("spam"))
-
-        verify(imp).load_source("build", "spam")
+        imp_load_source.assert_called_with("build", "spam")
 
     def test_ensure_project_attributes_are_set_when_instantiating_project(self):
-        module = mock(version="version",
-                      default_task="default_task",
-                      summary="summary",
-                      home_page="home_page",
-                      description="description",
-                      authors="authors",
-                      license="license",
-                      url="url")
+        module = ModuleType("mock_module")
 
-        self.reactor.project = mock()
+        module.version = "version"
+        module.default_task = "default_task"
+        module.summary = "summary"
+        module.home_page = "home_page"
+        module.description = "description"
+        module.authors = "authors"
+        module.license = "license"
+        module.url = "url"
+
+        self.reactor.project = Mock()
         self.reactor.project_module = module
 
         self.reactor.apply_project_attributes()
@@ -377,25 +380,25 @@ class ReactorTest(unittest.TestCase):
         self.assertEquals("url", self.reactor.project.url)
 
     def test_ensure_project_name_is_set_from_attribute_when_instantiating_project(self):
-        module = mock(name="name")
+        module = ModuleType("mock_module")
+        module.name = "mock_module"
 
-        self.reactor.project = mock()
+        self.reactor.project = Mock()
         self.reactor.project_module = module
         self.reactor.apply_project_attributes()
 
-        self.assertEquals("name", self.reactor.project.name)
+        self.assertEquals("mock_module", self.reactor.project.name)
 
     def test_should_import_plugin_only_once(self):
-        plugin_module = mock()
-        when(self.plugin_loader_mock).load_plugin(
-            any(), "spam", any()).thenReturn(plugin_module)
+        plugin_module = ModuleType("mock_module")
+        self.plugin_loader_mock.load_plugin.return_value = plugin_module
 
         self.reactor.require_plugin("spam")
         self.reactor.require_plugin("spam")
 
         self.assertEquals(["spam"], self.reactor.get_plugins())
 
-        verify(self.plugin_loader_mock).load_plugin(any(), "spam", None, None)
+        self.plugin_loader_mock.load_plugin.assert_called_with(ANY, "spam", None, None)
 
     def test_ensure_project_properties_are_logged_when_calling_log_project_properties(self):
         project = Project("spam")
@@ -405,15 +408,14 @@ class ReactorTest(unittest.TestCase):
         self.reactor.project = project
         self.reactor.log_project_properties()
 
-        verify(self.logger).debug(
-            "Project properties: %s", contains("basedir : spam"))
-        verify(self.logger).debug(
-            "Project properties: %s", contains("eggs : eggs"))
-        verify(self.logger).debug(
-            "Project properties: %s", contains("spam : spam"))
+        call_args = self.logger.debug.call_args
+        self.assertEquals(call_args[0][0], "Project properties: %s")
+        self.assertTrue("basedir : spam" in call_args[0][1])
+        self.assertTrue("eggs : eggs" in call_args[0][1])
+        self.assertTrue("spam : spam" in call_args[0][1])
 
     def test_should_raise_exception_when_project_is_not_valid(self):
-        self.reactor.project = mock(properties={})
-        when(self.reactor.project).validate().thenReturn(["spam"])
+        self.reactor.project = Mock(properties={})
+        self.reactor.project.validate.return_value = ["spam"]
 
         self.assertRaises(ProjectValidationFailedException, self.reactor.build)

--- a/src/unittest/python/scaffolding_tests.py
+++ b/src/unittest/python/scaffolding_tests.py
@@ -16,7 +16,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from mock import patch, call
+from test_utils import patch, call
 from unittest import TestCase
 
 from pybuilder.scaffolding import (PythonProjectScaffolding,

--- a/src/unittest/python/test_utils.py
+++ b/src/unittest/python/test_utils.py
@@ -16,20 +16,79 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import sys
+from functools import partial
+from traceback import extract_stack
 from unittest import TestCase
 
-import mockito
+if sys.version_info[0] == 2:
+    import mock
+else:
+    from unittest import mock
 
 
-def mock(mocked_obj=None, **keyword_arguments):
-    result = mockito.mock(mocked_obj)
-    for key in keyword_arguments:
-        setattr(result, key, keyword_arguments[key])
-    return result
+def _new_mock(*args, **kwargs):
+    mock_type = kwargs["mock_type"]
+    del kwargs["mock_type"]
+    mock_kwargs = dict(kwargs)
+
+    if "mock_name" in mock_kwargs:
+        mock_name = mock_kwargs["mock_name"]
+        del mock_kwargs["mock_name"]
+        mock_kwargs["name"] = mock_name
+
+    mock = mock_type(*args, **mock_kwargs)
+    if "name" in kwargs:
+        mock.name = kwargs["name"]
+    return mock
+
+
+class PyBuilderMock(mock.Mock):
+    def __init__(self, spec=None, wraps=None, name=None, spec_set=None,
+                 parent=None, _spec_state=None, _new_name='', _new_parent=None,
+                 _spec_as_instance=False, _eat_self=None, unsafe=False, **kwargs):
+        __dict__ = self.__dict__
+        __dict__['_mock_tb'] = extract_stack()
+        super(mock.Mock, self).__init__(spec=spec, wraps=wraps, name=name, spec_set=spec_set,
+                                        parent=parent,
+                                        _spec_state=_spec_state,
+                                        _new_name=_new_name,
+                                        _new_parent=_new_parent,
+                                        _spec_as_instance=_spec_as_instance,
+                                        _eat_self=_eat_self,
+                                        unsafe=unsafe, **kwargs)
+
+
+class PyBuilderMagicMock(mock.MagicMock):
+    def __init__(self, spec=None, wraps=None, name=None, spec_set=None,
+                 parent=None, _spec_state=None, _new_name='', _new_parent=None,
+                 _spec_as_instance=False, _eat_self=None, unsafe=False, **kwargs):
+        __dict__ = self.__dict__
+        __dict__['_mock_tb'] = extract_stack()
+        super(mock.MagicMock, self).__init__(spec=spec, wraps=wraps, name=name, spec_set=spec_set,
+                                             parent=parent,
+                                             _spec_state=_spec_state,
+                                             _new_name=_new_name,
+                                             _new_parent=_new_parent,
+                                             _spec_as_instance=_spec_as_instance,
+                                             _eat_self=_eat_self,
+                                             unsafe=unsafe, **kwargs)
+
+
+Mock = partial(_new_mock, mock_type=PyBuilderMock)
+MagicMock = partial(_new_mock, mock_type=PyBuilderMagicMock)
+patch = partial(mock.patch, new_callable=PyBuilderMagicMock)
+patch.object = partial(mock.patch.object, new_callable=PyBuilderMagicMock)
+patch.dict = mock.patch.dict
+patch.multiple = partial(mock.patch.multiple, new_callable=PyBuilderMagicMock)
+patch.stopall = mock.patch.stopall
+patch.TEST_PREFIX = 'test'
+DEFAULT = mock.DEFAULT
+call = mock.call
+ANY = mock.ANY
 
 
 class PyBuilderTestCase(TestCase):
-
     def assert_line_by_line_equal(self, expected_multi_line_string, actual_multi_line_string):
         expected_lines = expected_multi_line_string.split("\n")
         actual_lines = actual_multi_line_string.split("\n")
@@ -44,3 +103,6 @@ class PyBuilderTestCase(TestCase):
             self.assertEquals(expected_line, actual_line, message)
         self.assertEquals(len(expected_lines), len(actual_lines),
                           'Multi-line strings do not have the same number of lines')
+
+
+__all__ = [PyBuilderTestCase, Mock, MagicMock, patch, ANY, DEFAULT, call]

--- a/src/unittest/python/vcs_tests.py
+++ b/src/unittest/python/vcs_tests.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import patch
+from test_utils import patch
 
 from pybuilder.errors import PyBuilderException
 from pybuilder.vcs import VCSRevision


### PR DESCRIPTION
1. Got rid of Mockito entirely. This resulted in finding a huge bug in reactor tests whereas the plugin loader in the actual (not mocked) reactor was substituted with a mock plugin loader affecting further reactor behavior. https://github.com/pybuilder/pybuilder/pull/347/files#diff-9584cce2b40001f24aa966f2329c0bc7R50 https://github.com/pybuilder/pybuilder/pull/347/files#diff-9584cce2b40001f24aa966f2329c0bc7R421

2. We use Unittest.Mock where it is available and Mock elsewhere. Dependencies are adjusted accordingly.

3. All of the PIP internal stuff is moved into pip_common (to expose Version and SpecifierSet) while pip_utils contains PIP-related utilities. https://github.com/pybuilder/pybuilder/pull/347/files#diff-3f7930768a016caa358fe51c630f08cfR1

4. Corollary to self-updating (since we use PIP internals) is reloading of PIP post-update to allow incompatible migrations from 6 to 8 etc. https://github.com/pybuilder/pybuilder/pull/347/files#diff-001479a18f1db7b9cde893d99c6734f1R133

5. Logic related to what to install is concentrated here: https://github.com/pybuilder/pybuilder/pull/347/files#diff-001479a18f1db7b9cde893d99c6734f1R136

6. Logic related to how to install (if there are individual install targets or URL install causing force-reinstall must install separately, otherwise can batch) is here:
https://github.com/pybuilder/pybuilder/pull/347/files#diff-001479a18f1db7b9cde893d99c6734f1R106

fixes #346, connected to #346 