### PR TITLE
use shutil.rmtree instead of os.removedirs

### DIFF
--- a/src/main/python/pybuilder/scaffolding.py
+++ b/src/main/python/pybuilder/scaffolding.py
@@ -163,7 +163,7 @@ try:
         target_file_name = os.path.join(script_dir, file_name)
         if os.path.exists(target_file_name):
             if os.path.isdir(target_file_name):
-                os.removedirs(target_file_name)
+                shutil.rmtree(target_file_name)
             else:
                 os.remove(target_file_name)
         shutil.move(src_file, script_dir)


### PR DESCRIPTION
This fixes a bug in corner case in the `setup.py` shim/scaffolding generated by
PyBuilder. When using `install_file` and friends and installing the project via
git+ssh protocol the scaffolding `setup.py` crashes during cleanup, because
certain directories are non-empty.

In order to further demonstrate the issue, I have created a PyBuilder project
at:

https://github.com/esc/pybuilder-bug-expose

If you now try to install this project, you get:

```
% pip install "git+ssh://git@github.com/esc/pybuilder-bug-expose.git#egg=bug"
Collecting bug from git+ssh://git@github.com/esc/pybuilder-bug-expose.git#egg=bug
  Cloning ssh://git@github.com/esc/pybuilder-bug-expose.git to /tmp/pip-build-BE_AGP/bug
    Complete output from command python setup.py egg_info:
    pyb 0.11.8
    PyBuilder version 0.11.8
    Build started at 2016-06-15 16:46:45
    ------------------------------------------------------------
    [INFO]  Building bug version 1.0.dev0
    [INFO]  Executing build in /tmp/pip-build-BE_AGP/bug
    [INFO]  Going to execute tasks: clean, install_build_dependencies, package
    [INFO]  Removing target directory /tmp/pip-build-BE_AGP/bug/target
    [INFO]  Installing build dependencies
    [INFO]  Installing dependency 'mockito'
    [INFO]  Building distribution in /tmp/pip-build-BE_AGP/bug/target/dist/bug-1.0.dev0
    [INFO]  Copying scripts to /tmp/pip-build-BE_AGP/bug/target/dist/bug-1.0.dev0/scripts
    [INFO]  Copying resources matching 'foo/bar' from /tmp/pip-build-BE_AGP/bug to /tmp/pip-build-BE_AGP/bug/target/dist/bug-1.0.dev0
    [INFO]  Writing MANIFEST.in as /tmp/pip-build-BE_AGP/bug/target/dist/bug-1.0.dev0/MANIFEST.in
    [INFO]  Writing setup.py as /tmp/pip-build-BE_AGP/bug/target/dist/bug-1.0.dev0/setup.py
    ------------------------------------------------------------
    BUILD SUCCESSFUL
    ------------------------------------------------------------
    Build finished at 2016-06-15 16:46:45
    Build took 0 seconds (598 ms)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-BE_AGP/bug/setup.py", line 66, in <module>
        os.removedirs(target_file_name)
      File "/home/esc/gw/pybuilder-bug-expose/.venv/lib/python2.7/os.py", line 170, in removedirs
        rmdir(name)
    OSError: [Errno 39] Directory not empty: '/tmp/pip-build-BE_AGP/bug/foo'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-BE_AGP/bug/
```

This pull-request fixes this issue and ensures that the `setup.py` can
actually remove the directories.