### PR TITLE
adding count_travis

### DIFF
--- a/src/main/python/pybuilder/vcs.py
+++ b/src/main/python/pybuilder/vcs.py
@@ -21,6 +21,7 @@
     Provides version control system utilities.
 """
 
+import os
 from pybuilder.utils import execute_command_and_capture_output
 from pybuilder.errors import PyBuilderException
 
@@ -85,3 +86,9 @@ class VCSRevision(object):
             return False
 
         return True
+
+
+def count_travis():
+    """ Version number dervived from commit count and travis build number. """
+    return '{0}.{1}'.format(VCSRevision().count,
+                            os.environ.get('TRAVIS_BUILD_NUMBER', 0))


### PR DESCRIPTION
I think this is my current best take on CLD version numbers. Using the commit-count enables moving forward all the time and using the travis build-count means we get repeatable builds that can always upload a build-artifact. Since I am using this idiom in all of our projects right now, I am proposing that we include this in PyBuilder.