### PR TITLE
PyBuilder's setup.py broken when pandoc>=1.18 is installed with pypandoc~=1.2.0

### DIFF
--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -104,7 +104,7 @@ def default(value, default=""):
 
 @init
 def initialize_distutils_plugin(project):
-    project.plugin_depends_on("pypandoc", "~=1.2.0")
+    project.plugin_depends_on("pypandoc", "~=1.3.0")
 
     project.set_property_if_unset("distutils_commands", ["sdist", "bdist_wheel"])
     project.set_property_if_unset("distutils_command_options", None)


### PR DESCRIPTION
Pypandoc updated to ~=1.3.0

fixes #428