### PR TITLE
Prefix paths in discover_affected_files and discover_affected_dirs with project.basedir

### DIFF
--- a/src/main/python/pybuilder/plugins/python/python_plugin_helper.py
+++ b/src/main/python/pybuilder/plugins/python/python_plugin_helper.py
@@ -39,38 +39,51 @@ def discover_python_files(directory):
 
 
 def discover_affected_files(include_test_sources, include_scripts, project):
-    source_dir = project.get_property("dir_source_main_python")
+    source_dir = os.path.join(project.basedir, project.get_property("dir_source_main_python"))
     files = discover_python_files(source_dir)
 
     if include_test_sources:
         if project.get_property("dir_source_unittest_python"):
-            unittest_dir = project.get_property("dir_source_unittest_python")
+            unittest_dir = os.path.join(project.basedir, project.get_property("dir_source_unittest_python"))
             files = itertools.chain(files, discover_python_files(unittest_dir))
         if project.get_property("dir_source_integrationtest_python"):
-            integrationtest_dir = project.get_property("dir_source_integrationtest_python")
+            integrationtest_dir = os.path.join(project.basedir, project.get_property("dir_source_integrationtest_python"))
             files = itertools.chain(files, discover_python_files(integrationtest_dir))
     if include_scripts and project.get_property("dir_source_main_scripts"):
-        scripts_dir = project.get_property("dir_source_main_scripts")
+        scripts_dir = os.path.join(project.basedir, project.get_property("dir_source_main_scripts"))
         files = itertools.chain(files,
                                 discover_files_matching(scripts_dir, "*"))  # we have no idea how scripts might look
     return files
 
 
 def discover_affected_dirs(include_test_sources, include_scripts, project):
-    files = [project.get_property("dir_source_main_python")]
+    files = [os.path.join(project.basedir, project.get_property("dir_source_main_python"))]
+
     if include_test_sources:
-        if _if_property_set_and_dir_exists(project.get_property("dir_source_unittest_python")):
-            files.append(project.get_property("dir_source_unittest_python"))
-        if _if_property_set_and_dir_exists(project.get_property("dir_source_integrationtest_python")):
-            files.append(project.get_property("dir_source_integrationtest_python"))
-    if include_scripts and _if_property_set_and_dir_exists(project.get_property("dir_source_main_scripts")):
-        files.append(project.get_property("dir_source_main_scripts"))
+        if project.get_property("dir_source_unittest_python"):
+            unittest_dir = os.path.join(project.basedir, project.get_property("dir_source_unittest_python"))
+
+            if os.path.isdir(unittest_dir):
+                files.append(unittest_dir)
+
+        if project.get_property("dir_source_integrationtest_python"):
+            integrationtest_dir = os.path.join(project.basedir, project.get_property("dir_source_integrationtest_python"))
+
+            if os.path.isdir(integrationtest_dir):
+                files.append(integrationtest_dir)
+    
+    if include_scripts and project.get_property("dir_source_main_scripts"):
+        scripts_dir = os.path.join(project.basedir, project.get_property("dir_source_main_scripts"))
+
+        if os.path.isdir(scripts_dir):
+            files.append(scripts_dir)
+    
     return files
 
 
 def _if_property_set_and_dir_exists(property_value):
     return property_value and os.path.isdir(property_value)
-
+    
 
 def execute_tool_on_source_files(project, name, command_and_arguments, logger=None,
                                  include_test_sources=False, include_scripts=False, include_dirs_only=False):

--- a/src/unittest/python/plugins/python/python_plugin_helper_tests.py
+++ b/src/unittest/python/plugins/python/python_plugin_helper_tests.py
@@ -45,43 +45,43 @@ class LogReportsTest(unittest.TestCase):
 class DiscoverAffectedFilesTest(unittest.TestCase):
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     def test_should_discover_source_files_when_test_sources_not_included(self, discover_python_files):
-        project = Mock()
+        project = Mock(basedir="basedir")
         project.get_property.return_value = 'source_directory'
         discover_python_files.return_value = ['foo.py', 'bar.py']
 
         files = discover_affected_files(False, False, project)
-        discover_python_files.assert_called_with('source_directory')
+        discover_python_files.assert_called_with('basedir/source_directory')
         self.assertEqual(files, ['foo.py', 'bar.py'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     def test_should_discover_source_files_when_test_sources_are_included(self, discover_python_files):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.side_effect = lambda _property: _property
 
         discover_affected_files(True, False, project)
 
         self.assertEqual(discover_python_files.call_args_list,
-                         [call('dir_source_main_python'),
-                          call('dir_source_unittest_python'),
-                          call('dir_source_integrationtest_python')])
+                         [call('basedir/dir_source_main_python'),
+                          call('basedir/dir_source_unittest_python'),
+                          call('basedir/dir_source_integrationtest_python')])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_files_matching')
     def test_should_discover_source_files_when_scripts_are_included(self, discover_files_matching, _):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.return_value = True
         project.get_property.side_effect = lambda _property: _property
 
         discover_affected_files(False, True, project)
 
-        discover_files_matching.assert_called_with('dir_source_main_scripts', '*')
+        discover_files_matching.assert_called_with('basedir/dir_source_main_scripts', '*')
 
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     def test_should_discover_source_files_when_test_sources_are_included_and_only_unittests(self,
                                                                                             discover_python_files):
-        project = Mock()
+        project = Mock(basedir="basedir")
 
         def get_property(property):
             if property == 'dir_source_integrationtest_python':
@@ -93,13 +93,13 @@ class DiscoverAffectedFilesTest(unittest.TestCase):
         discover_affected_files(True, False, project)
 
         self.assertEqual(discover_python_files.call_args_list,
-                         [call('dir_source_main_python'),
-                          call('dir_source_unittest_python')])
+                         [call('basedir/dir_source_main_python'),
+                          call('basedir/dir_source_unittest_python')])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     def test_should_discover_source_files_when_test_sources_are_included_and_only_integrationtests(self,
                                                                                                    discover_python_files):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         def get_property(property):
             if property == 'dir_source_unittest_python':
@@ -111,12 +111,12 @@ class DiscoverAffectedFilesTest(unittest.TestCase):
         discover_affected_files(True, False, project)
 
         self.assertEqual(discover_python_files.call_args_list,
-                         [call('dir_source_main_python'),
-                          call('dir_source_integrationtest_python')])
+                         [call('basedir/dir_source_main_python'),
+                          call('basedir/dir_source_integrationtest_python')])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.discover_python_files')
     def test_should_discover_source_files_when_test_sources_are_included_and_no_tests(self, discover_python_files):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         def get_property(property):
             if property == 'dir_source_main_python':
@@ -128,20 +128,20 @@ class DiscoverAffectedFilesTest(unittest.TestCase):
         discover_affected_files(True, False, project)
 
         self.assertEqual(discover_python_files.call_args_list,
-                         [call('dir_source_main_python')])
+                         [call('basedir/dir_source_main_python')])
 
 
 class DiscoverAffectedDirsTest(unittest.TestCase):
     def test_should_discover_source_dirs_when_test_sources_not_included(self):
-        project = Mock()
+        project = Mock(basedir='basedir')
         project.get_property.return_value = 'source_directory'
 
         files = discover_affected_dirs(False, False, project)
-        self.assertEqual(files, ['source_directory'])
+        self.assertEqual(files, ['basedir/source_directory'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_test_sources_are_included(self, _):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.side_effect = lambda _property: _property
 
@@ -154,11 +154,11 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_integrationtest_python'),
                           call('dir_source_integrationtest_python')])
         self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_unittest_python', 'dir_source_integrationtest_python'])
+                          ['basedir/dir_source_main_python', 'basedir/dir_source_unittest_python', 'basedir/dir_source_integrationtest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_test_sources_are_included_no_unittests(self, _):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.side_effect = lambda \
             _property: _property if _property != 'dir_source_unittest_python' else None
@@ -171,11 +171,11 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_integrationtest_python'),
                           call('dir_source_integrationtest_python')])
         self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_integrationtest_python'])
+                          ['basedir/dir_source_main_python', 'basedir/dir_source_integrationtest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_test_sources_are_included_no_integrationtests(self, _):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.side_effect = lambda \
             _property: _property if _property != 'dir_source_integrationtest_python' else None
@@ -188,11 +188,11 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_unittest_python'),
                           call('dir_source_integrationtest_python')])
         self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_unittest_python'])
+                          ['basedir/dir_source_main_python', 'basedir/dir_source_unittest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_script_sources_are_included(self, _):
-        project = Mock()
+        project = Mock(basedir='basedir')
 
         project.get_property.side_effect = lambda \
             _property: _property if _property != 'dir_source_integrationtest_python' else None
@@ -204,7 +204,7 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_main_scripts'),
                           call('dir_source_main_scripts')])
         self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_main_scripts'])
+                          ['basedir/dir_source_main_python', 'basedir/dir_source_main_scripts'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_if_property_set_and_dir_exists(self, exists):


### PR DESCRIPTION
I like having a project structure with multiple modules:

```
src/module1/src/main/python
src/module2/src/main/python
```

Instead of having multiple `build.py` files at the base of each module I rather have a single one at the root of my project. I can easily achieve this by declaring an `@init` function for each submodule and changing the `project.basedir` attribute.

However, all linters break when doing this. I traced down the problem to the `discover_affected_dirs` function. Once you prepend the base directory everything seems to work fine.