### PR TITLE
Exposing Flake8 Code Complexity Property

### DIFF
--- a/src/main/python/pybuilder/plugins/python/flake8_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/flake8_plugin.py
@@ -45,7 +45,6 @@ def initialize_flake8_plugin(project):
     project.set_property_if_unset("flake8_include_test_sources", False)
     project.set_property_if_unset("flake8_include_scripts", False)
     project.set_property_if_unset("flake8_max_complexity", None)
-    project.set_property_if_unset("flake8_radon_max", None)
 
 
 @after("prepare")
@@ -73,7 +72,6 @@ def analyze(project, logger):
     command.use_argument('--filename={0}').formatted_with_truthy_property('flake8_include_patterns')
     command.use_argument('--exclude={0}').formatted_with_truthy_property('flake8_exclude_patterns')
     command.use_argument('--max-complexity={0}').formatted_with_truthy_property('flake8_max_complexity')
-    command.use_argument('--radon-max-cc={0}').formatted_with_truthy_property('flake8_radon_max')
 
     include_test_sources = project.get_property("flake8_include_test_sources")
     include_scripts = project.get_property("flake8_include_scripts")

--- a/src/main/python/pybuilder/plugins/python/flake8_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/flake8_plugin.py
@@ -44,6 +44,8 @@ def initialize_flake8_plugin(project):
     project.set_property_if_unset("flake8_exclude_patterns", None)
     project.set_property_if_unset("flake8_include_test_sources", False)
     project.set_property_if_unset("flake8_include_scripts", False)
+    project.set_property_if_unset("flake8_max_complexity", None)
+    project.set_property_if_unset("flake8_radon_max", None)
 
 
 @after("prepare")
@@ -70,6 +72,8 @@ def analyze(project, logger):
     command.use_argument('--max-line-length={0}').formatted_with_property('flake8_max_line_length')
     command.use_argument('--filename={0}').formatted_with_truthy_property('flake8_include_patterns')
     command.use_argument('--exclude={0}').formatted_with_truthy_property('flake8_exclude_patterns')
+    command.use_argument('--max-complexity={0}').formatted_with_truthy_property('flake8_max_complexity')
+    command.use_argument('--radon-max-cc={0}').formatted_with_truthy_property('flake8_radon_max')
 
     include_test_sources = project.get_property("flake8_include_test_sources")
     include_scripts = project.get_property("flake8_include_scripts")

--- a/src/unittest/python/plugins/python/flake8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/flake8_plugin_tests.py
@@ -22,7 +22,8 @@ class FlakePluginInitializationTests(TestCase):
             "flake8_include_patterns": "*.py",
             "flake8_exclude_patterns": ".svn",
             "flake8_include_test_sources": True,
-            "flake8_include_scripts": True
+            "flake8_include_scripts": True,
+            "flake8_max_complexity": 10
             }
         for property_name, property_value in expected_properties.items():
             self.project.set_property(property_name, property_value)
@@ -42,3 +43,5 @@ class FlakePluginInitializationTests(TestCase):
                 self.project.get_property("flake8_include_test_sources"), True)
             self.assertEquals(
                 self.project.get_property("flake8_include_scripts"), True)
+            self.assertEquals(
+                self.project.get_property("flake8_max_complexity"), True)

--- a/src/unittest/python/plugins/python/flake8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/flake8_plugin_tests.py
@@ -44,4 +44,4 @@ class FlakePluginInitializationTests(TestCase):
             self.assertEquals(
                 self.project.get_property("flake8_include_scripts"), True)
             self.assertEquals(
-                self.project.get_property("flake8_max_complexity"), True)
+                self.project.get_property("flake8_max_complexity"), 10)


### PR DESCRIPTION
Property by default is disabled, so if the user does not define it on build.py it will not affect the code.
But if the user adds a value it will set the code complexity parameter to check over the code 

