### PR TITLE
[487] using / as path separator in setup.py

### DIFF
--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -409,7 +409,7 @@ def build_scripts_string(project):
 
     scripts_dir = project.get_property("dir_dist_scripts")
     if scripts_dir:
-        scripts = list(map(lambda s: os.path.join(scripts_dir, s), scripts))
+        scripts = list(map(lambda s: '{}/{}'.format(scripts_dir, s), scripts))
 
     return build_string_from_array(scripts)
 


### PR DESCRIPTION
fixes: https://github.com/pybuilder/pybuilder/issues/487

using / as path separator in setup.py which is according to doc: http://setuptools.readthedocs.io/en/latest/setuptools.html (look for 'you must use a forward slash')