### PR TITLE
Add Pylint logs

### DIFF
--- a/build.py
+++ b/build.py
@@ -76,7 +76,7 @@ authors = [Author("Alexander Metzner", "alexander.metzner@gmail.com"),
            ]
 url = "http://pybuilder.github.io"
 license = "Apache License"
-version = "0.11.10"
+version = "0.11.11.dev"
 
 requires_python = ">=2.6,!=3.0,!=3.1,!=3.2,<3.7"
 

--- a/src/main/python/pybuilder/plugins/python/flake8_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/flake8_plugin.py
@@ -44,6 +44,7 @@ def initialize_flake8_plugin(project):
     project.set_property_if_unset("flake8_exclude_patterns", None)
     project.set_property_if_unset("flake8_include_test_sources", False)
     project.set_property_if_unset("flake8_include_scripts", False)
+    project.set_property_if_unset("flake8_max_complexity", None)
 
 
 @after("prepare")
@@ -70,6 +71,7 @@ def analyze(project, logger):
     command.use_argument('--max-line-length={0}').formatted_with_property('flake8_max_line_length')
     command.use_argument('--filename={0}').formatted_with_truthy_property('flake8_include_patterns')
     command.use_argument('--exclude={0}').formatted_with_truthy_property('flake8_exclude_patterns')
+    command.use_argument('--max-complexity={0}').formatted_with_truthy_property('flake8_max_complexity')
 
     include_test_sources = project.get_property("flake8_include_test_sources")
     include_scripts = project.get_property("flake8_include_scripts")

--- a/src/unittest/python/plugins/python/flake8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/flake8_plugin_tests.py
@@ -22,7 +22,8 @@ class FlakePluginInitializationTests(TestCase):
             "flake8_include_patterns": "*.py",
             "flake8_exclude_patterns": ".svn",
             "flake8_include_test_sources": True,
-            "flake8_include_scripts": True
+            "flake8_include_scripts": True,
+            "flake8_max_complexity": 10
             }
         for property_name, property_value in expected_properties.items():
             self.project.set_property(property_name, property_value)
@@ -42,3 +43,5 @@ class FlakePluginInitializationTests(TestCase):
                 self.project.get_property("flake8_include_test_sources"), True)
             self.assertEquals(
                 self.project.get_property("flake8_include_scripts"), True)
+            self.assertEquals(
+                self.project.get_property("flake8_max_complexity"), 10)


### PR DESCRIPTION
Pylint logs are shown in shell. Break of building in case of too low Pylint score or too high Pylint decrease added. Also build break on Pylint errors with option to switch it off. 