### PR TITLE
global properties from command line has to be set immediately

### DIFF
--- a/src/main/python/pybuilder/reactor.py
+++ b/src/main/python/pybuilder/reactor.py
@@ -102,18 +102,12 @@ class Reactor(object):
             project_directory, project_descriptor)
 
         self.logger.debug("Loading project module from %s", project_descriptor)
-
         self.project = Project(basedir=project_directory)
-
-        self.project_module = self.load_project_module(project_descriptor)
-
-        self.apply_project_attributes()
         self.override_properties(property_overrides)
-
+        self.project_module = self.load_project_module(project_descriptor)
+        self.apply_project_attributes()
         self.logger.debug("Have loaded plugins %s", ", ".join(self._plugins))
-
         self.collect_tasks_and_actions_and_initializers(self.project_module)
-
         self.execution_manager.resolve_dependencies(exclude_optional_tasks, exclude_tasks, exclude_all_optional)
 
     def build(self, tasks=None, environments=None):


### PR DESCRIPTION
Unfortunately, global property values from command line aren't set immediately after project object creation. And we cannot use it for plugins behaviour manage.