### PR TITLE
Rework failure reporting in plugins that use external tools

### DIFF
--- a/build.py
+++ b/build.py
@@ -96,6 +96,7 @@ def initialize(project):
     project.depends_on("pip", "~=9.0")
     project.depends_on("setuptools", "~=36.5")
     project.depends_on("wheel", "~=0.30")
+    project.depends_on("tailer", "~=0.4")
 
     project.set_property("verbose", True)
 

--- a/src/integrationtest/python/integrationtest_support.py
+++ b/src/integrationtest/python/integrationtest_support.py
@@ -78,7 +78,7 @@ class IntegrationTestSupport(unittest.TestCase):
     def assert_file_empty(self, name):
         self.assert_file_exists(name)
         full_path = self.full_path(name)
-        self.assertEquals(0, os.path.getsize(full_path), msg="File %s is not empty." % full_path)
+        self.assertEqual(0, os.path.getsize(full_path), msg="File %s is not empty." % full_path)
 
     def assert_file_contains(self, name, expected_content_part):
         full_path = self.full_path(name)
@@ -111,7 +111,7 @@ class IntegrationTestSupport(unittest.TestCase):
 
                 message = 'line {0} is not as expected.\n   expected: "{1}"\n    but got: "{2}"'.format(
                     actual_line_number, expected_line_showing_escaped_new_line, actual_line_showing_escaped_new_line)
-                self.assertEquals(expected_line, actual_line, message)
+                self.assertEqual(expected_line, actual_line, message)
 
         self.assertEqual(expected_lines, actual_line_number)
 

--- a/src/integrationtest/python/should_list_multiple_tasks_for_project_using_core_plugin_tests.py
+++ b/src/integrationtest/python/should_list_multiple_tasks_for_project_using_core_plugin_tests.py
@@ -32,7 +32,7 @@ use_plugin("core")
 
         tasks = reactor.get_tasks()
 
-        self.assertEquals(11, len(tasks))
+        self.assertEqual(11, len(tasks))
 
         task_names = list(map(lambda task: task.name, tasks))
 

--- a/src/integrationtest/python/should_list_single_task_for_simple_project_tests.py
+++ b/src/integrationtest/python/should_list_single_task_for_simple_project_tests.py
@@ -32,8 +32,8 @@ def my_task (): pass
         reactor = self.prepare_reactor()
 
         tasks = reactor.get_tasks()
-        self.assertEquals(1, len(tasks))
-        self.assertEquals("my_task", tasks[0].name)
+        self.assertEqual(1, len(tasks))
+        self.assertEqual("my_task", tasks[0].name)
 
 
 if __name__ == "__main__":

--- a/src/main/python/pybuilder/plugins/python/cram_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/cram_plugin.py
@@ -28,7 +28,7 @@ import os
 from pybuilder.core import after, task, init, use_plugin, depends, description
 from pybuilder.errors import BuildFailedException
 from pybuilder.plugins.python.python_plugin_helper import execute_command
-from pybuilder.utils import assert_can_execute, discover_files_matching, read_file
+from pybuilder.utils import assert_can_execute, discover_files_matching, read_file, tail_log
 
 __author__ = 'Valentin Haenel'
 
@@ -110,20 +110,13 @@ def run_cram_tests(project, logger):
                                   env=env,
                                   error_file_name=report_file)
 
+    if return_code != 0:
+        error_str = "Cram tests failed! See %s for full details:\n%s" % (report_file, tail_log(report_file))
+        logger.error(error_str)
+        raise BuildFailedException(error_str)
+
     report = read_file(report_file)
     result = report[-1][2:].strip()
-
-    if return_code != 0:
-        logger.error("Cram tests failed!")
-        if project.get_property("verbose"):
-            for line in report:
-                logger.error(line.rstrip())
-        else:
-            logger.error(result)
-
-        logger.error("See: '{0}' for details".format(report_file))
-        raise BuildFailedException("Cram tests failed!")
-
     logger.info("Cram tests were fine")
     logger.info(result)
 

--- a/src/main/python/pybuilder/plugins/python/flake8_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/flake8_plugin.py
@@ -25,11 +25,10 @@
 
 from pybuilder.core import after, task, init, use_plugin, depends
 from pybuilder.errors import BuildFailedException
-from pybuilder.utils import assert_can_execute
 from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
+from pybuilder.utils import assert_can_execute, tail_log
 
 __author__ = 'Michael Gruber'
-
 
 use_plugin("python.core")
 
@@ -85,7 +84,8 @@ def analyze(project, logger):
     count_of_errors = len(result.error_report_lines)
 
     if count_of_errors > 0:
-        logger.error('Errors while running flake8, see {0}'.format(result.error_report_file))
+        logger.error('Errors while running flake8. See %s for full details:\n%s' % (
+            result.error_report_file, tail_log(result.error_report_file)))
 
     if count_of_warnings > 0:
         if project.get_property("flake8_break_build"):

--- a/src/main/python/pybuilder/plugins/python/frosted_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/frosted_plugin.py
@@ -26,11 +26,10 @@
 
 from pybuilder.core import after, task, init, use_plugin, depends
 from pybuilder.errors import BuildFailedException
-from pybuilder.utils import assert_can_execute
 from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
+from pybuilder.utils import assert_can_execute, tail_log
 
-__author__ = 'Maximilien Riehl'
-
+__author__ = "Maximilien Riehl"
 
 use_plugin("python.core")
 
@@ -63,9 +62,9 @@ def analyze(project, logger):
     verbose = project.get_property("verbose")
     project.set_property_if_unset("frosted_verbose_output", verbose)
 
-    command = ExternalCommandBuilder('frosted', project)
-    for ignored_error_code in project.get_property('frosted_ignore', []):
-        command.use_argument('--ignore={0}'.format(ignored_error_code))
+    command = ExternalCommandBuilder("frosted", project)
+    for ignored_error_code in project.get_property("frosted_ignore", []):
+        command.use_argument("--ignore={0}".format(ignored_error_code))
 
     include_test_sources = project.get_property("frosted_include_test_sources")
     include_scripts = project.get_property("frosted_include_scripts")
@@ -78,7 +77,8 @@ def analyze(project, logger):
     count_of_errors = len(result.error_report_lines)
 
     if count_of_errors > 0:
-        logger.error('Errors while running frosted, see {0}'.format(result.error_report_file))
+        logger.error("Errors while running frosted. See %s for full details:\n%s" % (
+            result.error_report_file, tail_log(result.error_report_file)))
 
     if count_of_warnings > 0:
         if project.get_property("frosted_break_build"):

--- a/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
@@ -22,6 +22,8 @@ import collections
 import imp
 import sys
 
+# Plugin install_dependencies_plugin can reload pip_common and pip_utils. Do not use from ... import ...
+from pybuilder import pip_utils
 from pybuilder.core import (before,
                             task,
                             description,
@@ -30,10 +32,7 @@ from pybuilder.core import (before,
                             Dependency,
                             RequirementsFile)
 from pybuilder.errors import BuildFailedException
-from pybuilder.terminal import print_file_content
-from pybuilder.utils import mkdir, as_list, safe_log_file_name
-# Plugin install_dependencies_plugin can reload pip_common and pip_utils. Do not use from ... import ...
-from pybuilder import pip_utils
+from pybuilder.utils import mkdir, as_list, safe_log_file_name, tail_log
 
 __author__ = "Alexander Metzner, Arcadiy Ivanov"
 
@@ -219,13 +218,10 @@ def _do_install_dependency(logger, project, dependency, upgrade, eager_upgrade,
         else:
             dependency_name = " dependency '%s'." % dependency.name
 
-        if project.get_property("verbose"):
-            print_file_content(log_file)
-            raise BuildFailedException("Unable to install%s" % dependency_name)
-        else:
-            raise BuildFailedException("Unable to install%s See %s for details.",
-                                       dependency_name,
-                                       log_file)
+        raise BuildFailedException("Unable to install%s See %s for full details:\n%s",
+                                   dependency_name,
+                                   log_file,
+                                   tail_log(log_file))
 
 
 def __reload_pip_if_updated(logger, dependencies_to_install):

--- a/src/main/python/pybuilder/plugins/python/sphinx_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/sphinx_plugin.py
@@ -30,7 +30,8 @@ from pybuilder.core import after, depends, init, task, use_plugin
 from pybuilder.errors import BuildFailedException
 from pybuilder.utils import (execute_command,
                              assert_can_execute,
-                             as_list)
+                             as_list,
+                             tail_log)
 
 __author__ = 'Thomas Prebble', 'Marcel Wolf', 'Arcadiy Ivanov'
 
@@ -168,7 +169,9 @@ def run_sphinx_build(build_command, task_name, logger, project, builder=None):
 
     exit_code = execute_command(build_command, log_file, shell=False)
     if exit_code != 0:
-        raise BuildFailedException("Sphinx build command failed. See %s for details.", log_file)
+        raise BuildFailedException("Sphinx build command failed. See %s for full details:\n%s",
+                                   log_file,
+                                   tail_log(log_file))
 
 
 @task("sphinx_generate_documentation", "Generates documentation with sphinx")

--- a/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
@@ -25,7 +25,8 @@ from pybuilder.core import (after,
                             depends)
 from pybuilder.errors import BuildFailedException
 from pybuilder.utils import (assert_can_execute,
-                             execute_command
+                             execute_command,
+                             tail_log
                              )
 
 __author__ = 'Marcel Wolf'
@@ -102,4 +103,4 @@ def run_py2dsc_deb_build(build_command, task_name, logger, project):
         exit_code = execute_command(build_command, log_file, shell=True)
         if exit_code != 0:
             raise BuildFailedException(
-                "py2dsc_deb build command failed. See %s for details.", log_file)
+                "py2dsc_deb build command failed. See %s for full details:\n%s", log_file, tail_log(log_file))

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -194,6 +194,17 @@ def execute_command_and_capture_output(*command_and_arguments):
     return process_return_code, stdout, stderr
 
 
+def tail(file_path, lines=20):
+    import tailer
+
+    with open(file_path) as f:
+        return tailer.tail(f, lines)
+
+
+def tail_log(file_path, lines=20):
+    return "\n".join("\t" + l for l in tail(file_path, lines))
+
+
 def assert_can_execute(command_and_arguments, prerequisite, caller):
     with tempfile.NamedTemporaryFile() as f:
         try:

--- a/src/unittest/python/ci_server_interaction_tests.py
+++ b/src/unittest/python/ci_server_interaction_tests.py
@@ -48,7 +48,7 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TeamCityTestProxy)
+        self.assertEqual(type(proxy), TeamCityTestProxy)
 
     def test_should_use_teamcity_proxy_if_project_property_is_set_and_teamcity_in_environment(self):
         self.mock_os.environ = {"TEAMCITY_VERSION": "1.0.0"}
@@ -56,14 +56,14 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TeamCityTestProxy)
+        self.assertEqual(type(proxy), TeamCityTestProxy)
 
     def test_should_use_teamcity_proxy_if_teamcity_in_environment(self):
         self.mock_os.environ = {"TEAMCITY_VERSION": "1.0.0"}
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TeamCityTestProxy)
+        self.assertEqual(type(proxy), TeamCityTestProxy)
 
     def test_should_use_default_proxy_if_project_property_is_not_set(self):
         self.mock_os.environ = {}
@@ -71,7 +71,7 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TestProxy)
+        self.assertEqual(type(proxy), TestProxy)
 
     def test_should_use_default_proxy_if_project_property_is_set_but_coverage_is_running(self):
         self.mock_os.environ = {}
@@ -80,7 +80,7 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TestProxy)
+        self.assertEqual(type(proxy), TestProxy)
 
     def test_should_use_default_proxy_if_teamcity_in_environment_but_coverage_is_running(self):
         self.mock_os.environ = {"TEAMCITY_VERSION": "1.0.0"}
@@ -88,7 +88,7 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TestProxy)
+        self.assertEqual(type(proxy), TestProxy)
 
     def test_should_use_default_proxy_if_teamcity_in_environment_and_project_property_is_set_but_coverage_is_running(self):
         self.mock_os.environ = {"TEAMCITY_VERSION": "1.0.0"}
@@ -97,7 +97,7 @@ class TestProxyTests(unittest.TestCase):
 
         proxy = test_proxy_for(self.project)
 
-        self.assertEquals(type(proxy), TestProxy)
+        self.assertEqual(type(proxy), TestProxy)
 
 
 class TeamCityProxyTests(unittest.TestCase):

--- a/src/unittest/python/cli_tests.py
+++ b/src/unittest/python/cli_tests.py
@@ -135,56 +135,56 @@ class ColoredStdOutLoggerTest(unittest.TestCase):
 
 class ParseOptionsTest(unittest.TestCase):
     def assert_options(self, options, **overrides):
-        self.assertEquals(options.project_directory,
-                          overrides.get("project_directory", "."))
-        self.assertEquals(options.debug,
-                          overrides.get("debug", False))
-        self.assertEquals(options.quiet,
-                          overrides.get("quiet", False))
-        self.assertEquals(options.list_tasks,
-                          overrides.get("list_tasks", False))
-        self.assertEquals(options.no_color,
-                          overrides.get("no_color", False))
-        self.assertEquals(options.property_overrides,
-                          overrides.get("property_overrides", {}))
-        self.assertEquals(options.start_project,
-                          overrides.get("start_project", False))
+        self.assertEqual(options.project_directory,
+                         overrides.get("project_directory", "."))
+        self.assertEqual(options.debug,
+                         overrides.get("debug", False))
+        self.assertEqual(options.quiet,
+                         overrides.get("quiet", False))
+        self.assertEqual(options.list_tasks,
+                         overrides.get("list_tasks", False))
+        self.assertEqual(options.no_color,
+                         overrides.get("no_color", False))
+        self.assertEqual(options.property_overrides,
+                         overrides.get("property_overrides", {}))
+        self.assertEqual(options.start_project,
+                         overrides.get("start_project", False))
 
     def test_should_parse_empty_arguments(self):
         options, arguments = parse_options([])
 
         self.assert_options(options)
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_parse_task_list_without_options(self):
         options, arguments = parse_options(["clean", "spam"])
 
         self.assert_options(options)
-        self.assertEquals(["clean", "spam"], arguments)
+        self.assertEqual(["clean", "spam"], arguments)
 
     def test_should_parse_start_project_without_options(self):
         options, arguments = parse_options(["clean", "spam"])
 
         self.assert_options(options)
-        self.assertEquals(["clean", "spam"], arguments)
+        self.assertEqual(["clean", "spam"], arguments)
 
     def test_should_parse_empty_arguments_with_option(self):
         options, arguments = parse_options(["-X"])
 
         self.assert_options(options, debug=True)
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_parse_arguments_and_option(self):
         options, arguments = parse_options(["-X", "-D", "spam", "eggs"])
 
         self.assert_options(options, debug=True, project_directory="spam")
-        self.assertEquals(["eggs"], arguments)
+        self.assertEqual(["eggs"], arguments)
 
     def test_should_set_property(self):
         options, arguments = parse_options(["-P", "spam=eggs"])
 
         self.assert_options(options, property_overrides={"spam": "eggs"})
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_set_multiple_properties(self):
         options, arguments = parse_options(["-P", "spam=eggs",
@@ -192,7 +192,7 @@ class ParseOptionsTest(unittest.TestCase):
 
         self.assert_options(options, property_overrides={"spam": "eggs",
                                                          "foo": "bar"})
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_abort_execution_when_property_definition_has_syntax_error(self):
         self.assertRaises(
@@ -202,19 +202,19 @@ class ParseOptionsTest(unittest.TestCase):
         options, arguments = parse_options(["-E", "spam"])
 
         self.assert_options(options, environments=["spam"])
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_parse_multiple_environments(self):
         options, arguments = parse_options(["-E", "spam", "-E", "eggs"])
 
         self.assert_options(options, environments=["spam", "eggs"])
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
     def test_should_parse_empty_environments(self):
         options, arguments = parse_options([])
 
         self.assert_options(options, environments=[])
-        self.assertEquals([], arguments)
+        self.assertEqual([], arguments)
 
 
 class LengthOfLongestStringTests(unittest.TestCase):

--- a/src/unittest/python/core_tests.py
+++ b/src/unittest/python/core_tests.py
@@ -37,15 +37,15 @@ class ProjectTest(unittest.TestCase):
     def test_should_pick_directory_name_for_project_name_when_name_is_not_given(self, os_path_basename):
         project = Project(basedir="/imaginary")
 
-        self.assertEquals("imaginary", project.name)
+        self.assertEqual("imaginary", project.name)
         os_path_basename.assert_called_with("/imaginary")
 
     def test_get_property_should_return_default_value_when_property_is_not_set(self):
-        self.assertEquals("spam", self.project.get_property("spam", "spam"))
+        self.assertEqual("spam", self.project.get_property("spam", "spam"))
 
     def test_get_property_should_return_property_value_when_property_is_set(self):
         self.project.set_property("spam", "eggs")
-        self.assertEquals("eggs", self.project.get_property("spam", "spam"))
+        self.assertEqual("eggs", self.project.get_property("spam", "spam"))
 
     def test_has_property_should_return_false_when_property_is_not_set(self):
         self.assertFalse(self.project.has_property("spam"))
@@ -56,12 +56,12 @@ class ProjectTest(unittest.TestCase):
 
     def test_set_property_if_unset_should_set_property_when_property_is_not_set(self):
         self.project.set_property_if_unset("spam", "spam")
-        self.assertEquals("spam", self.project.get_property("spam"))
+        self.assertEqual("spam", self.project.get_property("spam"))
 
     def test_set_property_if_unset_should_not_set_property_when_property_is_already_set(self):
         self.project.set_property("spam", "eggs")
         self.project.set_property_if_unset("spam", "spam")
-        self.assertEquals("eggs", self.project.get_property("spam"))
+        self.assertEqual("eggs", self.project.get_property("spam"))
 
     def test_expand_should_raise_exception_when_property_is_not_set(self):
         self.assertRaises(
@@ -69,18 +69,18 @@ class ProjectTest(unittest.TestCase):
 
     def test_expand_should_return_expanded_string_when_property_is_set(self):
         self.project.set_property("spam", "eggs")
-        self.assertEquals("eggs", self.project.expand("$spam"))
+        self.assertEqual("eggs", self.project.expand("$spam"))
 
     def test_expand_should_return_expanded_string_when_two_properties_are_found_and_set(self):
         self.project.set_property("spam", "spam")
         self.project.set_property("eggs", "eggs")
-        self.assertEquals(
+        self.assertEqual(
             "spam and eggs", self.project.expand("$spam and $eggs"))
 
     def test_expand_should_expand_property_with_value_being_an_property_expression(self):
         self.project.set_property("spam", "spam")
         self.project.set_property("eggs", "$spam")
-        self.assertEquals("spam", self.project.expand("$eggs"))
+        self.assertEqual("spam", self.project.expand("$eggs"))
 
     def test_expand_should_raise_exception_when_first_expansion_leads_to_property_reference_and_property_is_undefined(
             self):
@@ -91,13 +91,13 @@ class ProjectTest(unittest.TestCase):
     def test_expand_path_should_return_expanded_path(self):
         self.project.set_property("spam", "spam")
         self.project.set_property("eggs", "eggs")
-        self.assertEquals(os.path.join("/imaginary", "spam", "eggs"),
-                          self.project.expand_path("$spam/$eggs"))
+        self.assertEqual(os.path.join("/imaginary", "spam", "eggs"),
+                         self.project.expand_path("$spam/$eggs"))
 
     def test_expand_path_should_return_expanded_path_and_additional_parts_when_additional_parts_are_given(self):
         self.project.set_property("spam", "spam")
         self.project.set_property("eggs", "eggs")
-        self.assertEquals(
+        self.assertEqual(
             os.path.join("/imaginary", "spam", "eggs", "foo", "bar"),
             self.project.expand_path("$spam/$eggs", "foo", "bar"))
 
@@ -107,26 +107,26 @@ class ProjectTest(unittest.TestCase):
 
     def test_should_return_property_value_when_getting_mandatory_propert_and_property_exists(self):
         self.project.set_property("spam", "spam")
-        self.assertEquals("spam", self.project.get_mandatory_property("spam"))
+        self.assertEqual("spam", self.project.get_mandatory_property("spam"))
 
     def test_should_add_runtime_dependency_with_name_only(self):
         self.project.depends_on("spam")
-        self.assertEquals(1, len(self.project.dependencies))
-        self.assertEquals("spam", self.project.dependencies[0].name)
-        self.assertEquals(None, self.project.dependencies[0].version)
+        self.assertEqual(1, len(self.project.dependencies))
+        self.assertEqual("spam", self.project.dependencies[0].name)
+        self.assertEqual(None, self.project.dependencies[0].version)
 
     def test_should_add_dependency_with_name_and_version(self):
         self.project.depends_on("spam", "0.7")
-        self.assertEquals(1, len(self.project.dependencies))
-        self.assertEquals("spam", self.project.dependencies[0].name)
-        self.assertEquals(">=0.7", self.project.dependencies[0].version)
+        self.assertEqual(1, len(self.project.dependencies))
+        self.assertEqual("spam", self.project.dependencies[0].name)
+        self.assertEqual(">=0.7", self.project.dependencies[0].version)
 
     def test_should_add_dependency_with_name_and_version_only_once(self):
         self.project.depends_on("spam", "0.7")
         self.project.depends_on("spam", "0.7")
-        self.assertEquals(1, len(self.project.dependencies))
-        self.assertEquals("spam", self.project.dependencies[0].name)
-        self.assertEquals(">=0.7", self.project.dependencies[0].version)
+        self.assertEqual(1, len(self.project.dependencies))
+        self.assertEqual("spam", self.project.dependencies[0].name)
+        self.assertEqual(">=0.7", self.project.dependencies[0].version)
 
 
 class ProjectManifestTests(unittest.TestCase):
@@ -150,30 +150,30 @@ class ProjectManifestTests(unittest.TestCase):
 
     def test_should_add_filename_to_list_of_included_files(self):
         self.project._manifest_include("spam")
-        self.assertEquals(["spam"], self.project.manifest_included_files)
+        self.assertEqual(["spam"], self.project.manifest_included_files)
 
     def test_should_add_filenames_in_correct_order_to_list_of_included_files(self):
         self.project._manifest_include("spam")
         self.project._manifest_include("egg")
         self.project._manifest_include("yadt")
-        self.assertEquals(
+        self.assertEqual(
             ["spam", "egg", "yadt"], self.project.manifest_included_files)
 
     def test_should_add_directory_to_list_of_includes(self):
         self.project._manifest_include_directory('yadt', ('egg', 'spam',))
-        self.assertEquals([('yadt', ('egg', 'spam',)), ],
-                          self.project.manifest_included_directories)
+        self.assertEqual([('yadt', ('egg', 'spam',)), ],
+                         self.project.manifest_included_directories)
 
     def test_should_add_directories_in_correct_order_to_list_of_includes(self):
         self.project._manifest_include_directory('spam', ('*',))
         self.project._manifest_include_directory('egg', ('*',))
         self.project._manifest_include_directory('yadt/spam', ('*',))
 
-        self.assertEquals([('spam', ('*',)),
-                           ('egg', ('*',)),
-                           ('yadt/spam', ('*',)),
-                           ],
-                          self.project.manifest_included_directories)
+        self.assertEqual([('spam', ('*',)),
+                          ('egg', ('*',)),
+                          ('yadt/spam', ('*',)),
+                          ],
+                         self.project.manifest_included_directories)
 
 
 class ProjectPackageDataTests(unittest.TestCase):
@@ -208,33 +208,33 @@ class ProjectPackageDataTests(unittest.TestCase):
         self.assertRaises(ValueError, self.project.include_directory, "spam", ["\t   \n"])
 
     def test_should_package_data_dictionary_is_empty(self):
-        self.assertEquals({}, self.project.package_data)
+        self.assertEqual({}, self.project.package_data)
 
     def test_should_add_filename_to_list_of_included_files_for_package_spam(self):
         self.project.include_file("spam", "eggs")
 
-        self.assertEquals({"spam": ["eggs"]}, self.project.package_data)
+        self.assertEqual({"spam": ["eggs"]}, self.project.package_data)
 
     def test_should_add_two_filenames_to_list_of_included_files_for_package_spam(self):
         self.project.include_file("spam", "eggs")
         self.project.include_file("spam", "ham")
 
-        self.assertEquals({"spam": ["eggs", "ham"]}, self.project.package_data)
+        self.assertEqual({"spam": ["eggs", "ham"]}, self.project.package_data)
 
     def test_should_add_two_filenames_to_list_of_included_files_for_two_different_packages(self):
         self.project.include_file("spam", "eggs")
         self.project.include_file("monty", "ham")
 
-        self.assertEquals(
+        self.assertEqual(
             {"monty": ["ham"], "spam": ["eggs"]}, self.project.package_data)
 
     def test_should_add_two_filenames_to_list_of_included_files_and_to_manifest(self):
         self.project.include_file("spam", "eggs")
         self.project.include_file("monty", "ham")
 
-        self.assertEquals(
+        self.assertEqual(
             {"monty": ["ham"], "spam": ["eggs"]}, self.project.package_data)
-        self.assertEquals(
+        self.assertEqual(
             ["spam/eggs", "monty/ham"], self.project.manifest_included_files)
 
 
@@ -243,12 +243,12 @@ class ProjectDataFilesTests(unittest.TestCase):
         self.project = Project(basedir="/imaginary", name="Unittest")
 
     def test_should_return_empty_list_for_property_files_to_install(self):
-        self.assertEquals([], self.project.files_to_install)
+        self.assertEqual([], self.project.files_to_install)
 
     def test_should_return_file_to_install(self):
         self.project.install_file("destination", "filename")
 
-        self.assertEquals(
+        self.assertEqual(
             [("destination", ["filename"])], self.project.files_to_install)
 
     def test_should_raise_exception_when_no_destination_given(self):
@@ -267,7 +267,7 @@ class ProjectDataFilesTests(unittest.TestCase):
         self.project.install_file("destination", "filename1")
         self.project.install_file("destination", "filename2")
 
-        self.assertEquals(
+        self.assertEqual(
             [("destination", ["filename1", "filename2"])], self.project.files_to_install)
 
     def test_should_return_files_to_install_into_different_destinations(self):
@@ -275,18 +275,18 @@ class ProjectDataFilesTests(unittest.TestCase):
         self.project.install_file("destination_a", "filename_a_2")
         self.project.install_file("destination_b", "filename_b")
 
-        self.assertEquals([("destination_a", ["filename_a_1", "filename_a_2"]),
-                           ("destination_b", ["filename_b"])], self.project.files_to_install)
+        self.assertEqual([("destination_a", ["filename_a_1", "filename_a_2"]),
+                          ("destination_b", ["filename_b"])], self.project.files_to_install)
 
     def test_should_return_files_to_install_into_different_destinations_and_add_them_to_manifest(self):
         self.project.install_file("destination_a", "somepackage1/filename1")
         self.project.install_file("destination_a", "somepackage2/filename2")
         self.project.install_file("destination_b", "somepackage3/filename3")
 
-        self.assertEquals(
+        self.assertEqual(
             [("destination_a", ["somepackage1/filename1", "somepackage2/filename2"]),
              ("destination_b", ["somepackage3/filename3"])], self.project.files_to_install)
-        self.assertEquals(
+        self.assertEqual(
             ["somepackage1/filename1", "somepackage2/filename2", "somepackage3/filename3"],
             self.project.manifest_included_files)
 

--- a/src/unittest/python/errors_tests.py
+++ b/src/unittest/python/errors_tests.py
@@ -23,7 +23,7 @@ from pybuilder.errors import PyBuilderException
 
 class PyBuilderExceptionTest(unittest.TestCase):
     def test_should_format_exception_message_without_arguments(self):
-        self.assertEquals("spam and eggs", str(PyBuilderException("spam and eggs")))
+        self.assertEqual("spam and eggs", str(PyBuilderException("spam and eggs")))
 
     def test_should_format_exception_message_with_arguments(self):
-        self.assertEquals("spam and eggs", str(PyBuilderException("%s and %s", "spam", "eggs")))
+        self.assertEqual("spam and eggs", str(PyBuilderException("%s and %s", "spam", "eggs")))

--- a/src/unittest/python/execution_tests.py
+++ b/src/unittest/python/execution_tests.py
@@ -28,17 +28,17 @@ from test_utils import Mock, ANY, call
 
 class AsTaskNameList(unittest.TestCase):
     def test_should_return_list_of_strings_when_string_given(self):
-        self.assertEquals(["spam"], as_task_name_list("spam"))
+        self.assertEqual(["spam"], as_task_name_list("spam"))
 
     def test_should_return_list_of_strings_when_list_of_strings_given(self):
-        self.assertEquals(
+        self.assertEqual(
             ["spam", "eggs"], as_task_name_list(["spam", "eggs"]))
 
     def test_should_return_list_of_strings_when_function_given(self):
         def spam():
             pass
 
-        self.assertEquals(["spam"], as_task_name_list(spam))
+        self.assertEqual(["spam"], as_task_name_list(spam))
 
     def test_should_return_list_of_strings_when_list_of_functions_given(self):
         def spam():
@@ -47,7 +47,7 @@ class AsTaskNameList(unittest.TestCase):
         def eggs():
             pass
 
-        self.assertEquals(["spam", "eggs"], as_task_name_list([spam, eggs]))
+        self.assertEqual(["spam", "eggs"], as_task_name_list([spam, eggs]))
 
 
 class ExecutableTest(unittest.TestCase):
@@ -86,7 +86,7 @@ class ExecutableTest(unittest.TestCase):
         Executable("callable", callable).execute({"spam": "spam"})
 
         self.assertTrue(callable.called)
-        self.assertEquals("spam", callable.spam)
+        self.assertEqual("spam", callable.spam)
 
     def test_should_raise_exception_when_callable_argument_cannot_be_satisfied(self):
         def callable(spam):
@@ -103,9 +103,9 @@ class ActionTest(unittest.TestCase):
 
         action = Action("callable", callable, "before", "after", "description")
 
-        self.assertEquals(["before"], action.execute_before)
-        self.assertEquals(["after"], action.execute_after)
-        self.assertEquals("description", action.description)
+        self.assertEqual(["before"], action.execute_before)
+        self.assertEqual(["after"], action.execute_after)
+        self.assertEqual("description", action.description)
 
 
 class TaskTest(unittest.TestCase):
@@ -115,7 +115,7 @@ class TaskTest(unittest.TestCase):
 
         task_list = [task_b, task_a]
 
-        self.assertEquals(["a_name", "b_name"], [
+        self.assertEqual(["a_name", "b_name"], [
             task.name for task in sorted(task_list)])
 
     def test_should_initialize_fields(self):
@@ -124,8 +124,8 @@ class TaskTest(unittest.TestCase):
 
         task = Task("callable", callable, "dependency", "description")
 
-        self.assertEquals(["dependency"], task.dependencies)
-        self.assertEquals(["description"], task.description)
+        self.assertEqual(["dependency"], task.dependencies)
+        self.assertEqual(["description"], task.description)
 
     def test_should_execute_callable_without_arguments(self):
         def callable():
@@ -147,7 +147,7 @@ class TaskTest(unittest.TestCase):
         Task("callable", callable).execute(Mock(), {"spam": "spam"})
 
         self.assertTrue(callable.called)
-        self.assertEquals("spam", callable.spam)
+        self.assertEqual("spam", callable.spam)
 
     def test_should_raise_exception_when_callable_argument_cannot_be_satisfied(self):
         def callable(spam):
@@ -171,10 +171,10 @@ class TaskExtensionTest(unittest.TestCase):
 
         task.extend(replacement)
 
-        self.assertEquals("task", task.name)
-        self.assertEquals(
+        self.assertEqual("task", task.name)
+        self.assertEqual(
             ["dependency", "another_dependency"], task.dependencies)
-        self.assertEquals(
+        self.assertEqual(
             ["description", "replacement description"], task.description)
 
     def test_should_execute_both_callables_when_extending_task(self):
@@ -253,7 +253,7 @@ class ExecutionManagerInitializerTest(ExecutionManagerTestBase):
     def test_ensure_that_initializer_is_added_when_calling_register_initializer(self):
         initializer = Mock()
         self.execution_manager.register_initializer(initializer)
-        self.assertEquals([initializer], self.execution_manager.initializers)
+        self.assertEqual([initializer], self.execution_manager.initializers)
 
     def test_ensure_that_registered_initializers_are_executed_when_calling_execute_initializers(self):
         initializer_1 = Mock()
@@ -286,7 +286,7 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
     def test_ensure_task_is_added_when_calling_register_task(self):
         task = Mock()
         self.execution_manager.register_task(task)
-        self.assertEquals([task], self.execution_manager.tasks)
+        self.assertEqual([task], self.execution_manager.tasks)
 
     def test_ensure_task_is_replaced_when_registering_two_tasks_with_same_name(self):
         original = Mock(name="spam")
@@ -351,8 +351,8 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
             self.execution_manager.execute_task(task)
             self.assertTrue(False, "should not have reached here")
         except Exception as e:
-            self.assertEquals(type(e), ValueError)
-            self.assertEquals(str(e), "simulated task error")
+            self.assertEqual(type(e), ValueError)
+            self.assertEqual(str(e), "simulated task error")
 
         action.execute.assert_called_with({})
         task.execute.assert_called_with(ANY, {})
@@ -376,8 +376,8 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
             self.execution_manager.execute_task(task)
             self.assertTrue(False, "should not have reached here")
         except Exception as e:
-            self.assertEquals(type(e), ValueError)
-            self.assertEquals(str(e), "simulated action error")
+            self.assertEqual(type(e), ValueError)
+            self.assertEqual(str(e), "simulated action error")
 
         task.execute.assert_called_with(ANY, {})
         action_regular.execute.assert_called_with({})
@@ -403,8 +403,8 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
             self.execution_manager.execute_task(task)
             self.assertTrue(False, "should not have reached here")
         except Exception as e:
-            self.assertEquals(type(e), ValueError)
-            self.assertEquals(str(e), "simulated action error")
+            self.assertEqual(type(e), ValueError)
+            self.assertEqual(str(e), "simulated action error")
 
         task.execute.assert_called_with(ANY, {})
         action_regular.execute.assert_called_with({})
@@ -429,8 +429,8 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
             self.execution_manager.execute_task(task)
             self.assertTrue(False, "should not have reached here")
         except Exception as e:
-            self.assertEquals(type(e), ValueError)
-            self.assertEquals(str(e), "simulated task error")
+            self.assertEqual(type(e), ValueError)
+            self.assertEqual(str(e), "simulated task error")
 
         task.execute.assert_called_with(ANY, {})
         action_teardown1.execute.assert_called_with({})
@@ -441,19 +441,19 @@ class ExecutionManagerTaskTest(ExecutionManagerTestBase):
 
     def test_should_return_single_task_name(self):
         self.execution_manager.register_task(Mock(name="spam"))
-        self.assertEquals(["spam"], self.execution_manager.task_names)
+        self.assertEqual(["spam"], self.execution_manager.task_names)
 
     def test_should_return_all_task_names(self):
         self.execution_manager.register_task(
             Mock(name="spam"), Mock(name="eggs"))
-        self.assertEquals(["eggs", "spam"], self.execution_manager.task_names)
+        self.assertEqual(["eggs", "spam"], self.execution_manager.task_names)
 
 
 class ExecutionManagerActionTest(ExecutionManagerTestBase):
     def test_ensure_action_is_registered(self):
         action = Mock(name="action")
         self.execution_manager.register_action(action)
-        self.assertEquals({"action": action}, self.execution_manager._actions)
+        self.assertEqual({"action": action}, self.execution_manager._actions)
 
     def test_ensure_action_registered_for_two_tasks_is_executed_two_times(self):
         spam = Mock(name="spam", dependencies=[])
@@ -534,8 +534,8 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
 
     def test_ensure_that_dependencies_are_resolved_when_task_depends_on_multiple_tasks(self):
         one = Mock(name="one", dependencies=[])
@@ -545,9 +545,9 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two, three)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
-        self.assertEquals(
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual(
             [TaskDependency(one), TaskDependency(two)], self.execution_manager._task_dependencies.get("three"))
 
     def test_override_optional_dependency_with_required(self):
@@ -557,8 +557,8 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
 
     def test_ignore_required_override_with_optional_dependency(self):
         one = Mock(name="one", dependencies=[])
@@ -567,8 +567,8 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
 
     def test_ignore_second_optional_dependency(self):
         one = Mock(name="one", dependencies=[])
@@ -577,8 +577,8 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one, True)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one, True)], self.execution_manager._task_dependencies.get("two"))
 
     def test_ignore_second_required_dependency(self):
         one = Mock(name="one", dependencies=[])
@@ -587,8 +587,8 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one)], self.execution_manager._task_dependencies.get("two"))
 
     def test_verify_late_dependency(self):
         one = Mock(name="one", dependencies=[])
@@ -600,11 +600,11 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
         self.execution_manager.register_late_task_dependencies({"two": [TaskDependency("three")]})
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one), TaskDependency(three)],
-                          self.execution_manager._task_dependencies.get("two"))
-        self.assertEquals([TaskDependency(one)],
-                          self.execution_manager._task_dependencies.get("three"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one), TaskDependency(three)],
+                         self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([TaskDependency(one)],
+                         self.execution_manager._task_dependencies.get("three"))
 
     def test_verify_duplicate_late_dependency_removed(self):
         one = Mock(name="one", dependencies=[])
@@ -617,11 +617,11 @@ class ExecutionManagerResolveDependenciesTest(ExecutionManagerTestBase):
             {"two": [TaskDependency("three"), TaskDependency("three")]})
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([], self.execution_manager._task_dependencies.get("one"))
-        self.assertEquals([TaskDependency(one), TaskDependency(three)],
-                          self.execution_manager._task_dependencies.get("two"))
-        self.assertEquals([TaskDependency(one)],
-                          self.execution_manager._task_dependencies.get("three"))
+        self.assertEqual([], self.execution_manager._task_dependencies.get("one"))
+        self.assertEqual([TaskDependency(one), TaskDependency(three)],
+                         self.execution_manager._task_dependencies.get("two"))
+        self.assertEqual([TaskDependency(one)],
+                         self.execution_manager._task_dependencies.get("three"))
 
     def test_verify_error_unresolved_late_dependency(self):
         one = Mock(name="one", dependencies=[])
@@ -786,12 +786,12 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
         self.execution_manager.register_task(one, two, three)
         self.execution_manager.resolve_dependencies()
 
-        self.assertEquals([one, two], self.execution_manager.build_execution_plan("two"))
+        self.assertEqual([one, two], self.execution_manager.build_execution_plan("two"))
 
         self.execution_manager._tasks_executed.append(one)
         self.execution_manager._tasks_executed.append(two)
 
-        self.assertEquals([three], self.execution_manager.build_shortest_execution_plan("three"))
+        self.assertEqual([three], self.execution_manager.build_shortest_execution_plan("three"))
 
     def test_shortest_execution_plan_always_executes_target(self):
         one = Mock(name="one", dependencies=[])
@@ -804,10 +804,10 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
         self.execution_manager._tasks_executed.append(one)
         self.execution_manager._tasks_executed.append(two)
 
-        self.assertEquals([three], self.execution_manager.build_shortest_execution_plan("three"))
+        self.assertEqual([three], self.execution_manager.build_shortest_execution_plan("three"))
 
         self.execution_manager._tasks_executed.append(three)
-        self.assertEquals([three], self.execution_manager.build_shortest_execution_plan("three"))
+        self.assertEqual([three], self.execution_manager.build_shortest_execution_plan("three"))
 
     def test_shortest_execution_plan_checks_circularity(self):
         one = Mock(name="one", dependencies=[])
@@ -834,9 +834,9 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
         self.execution_manager._tasks_executed.append(one)
         self.execution_manager._tasks_executed.append(two)
 
-        self.assertEquals([two, three], self.execution_manager.build_shortest_execution_plan(("two", "three")))
-        self.assertEquals([two, three], self.execution_manager.build_shortest_execution_plan(("three", "two")))
-        self.assertEquals([one, two, three], self.execution_manager.build_shortest_execution_plan(("three", "one")))
+        self.assertEqual([two, three], self.execution_manager.build_shortest_execution_plan(("two", "three")))
+        self.assertEqual([two, three], self.execution_manager.build_shortest_execution_plan(("three", "two")))
+        self.assertEqual([one, two, three], self.execution_manager.build_shortest_execution_plan(("three", "one")))
 
     def test_ensure_that_optional_tasks_are_excluded(self):
         one = Mock(name="one", dependencies=[])
@@ -847,7 +847,7 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
 
         execution_plan = self.execution_manager.build_execution_plan("two")
 
-        self.assertEquals([two], execution_plan)
+        self.assertEqual([two], execution_plan)
 
     def test_ensure_that_optional_branch_is_excluded(self):
         one = Mock(name="one", dependencies=[])
@@ -859,7 +859,7 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
 
         execution_plan = self.execution_manager.build_execution_plan("three")
 
-        self.assertEquals([three], execution_plan)
+        self.assertEqual([three], execution_plan)
 
     def test_ensure_that_required_tasks_are_force_excluded(self):
         one = Mock(name="one", dependencies=[])
@@ -870,7 +870,7 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
 
         execution_plan = self.execution_manager.build_execution_plan("two")
 
-        self.assertEquals([two], execution_plan)
+        self.assertEqual([two], execution_plan)
 
     def test_ensure_that_required_branch_is_force_excluded(self):
         one = Mock(name="one", dependencies=[])
@@ -882,7 +882,7 @@ class ExecutionManagerBuildExecutionPlanTest(ExecutionManagerTestBase):
 
         execution_plan = self.execution_manager.build_execution_plan("three")
 
-        self.assertEquals([three], execution_plan)
+        self.assertEqual([three], execution_plan)
 
     def test_ensure_that_required_tasks_are_not_optionally_excluded(self):
         one = Mock(name="one", dependencies=[])

--- a/src/unittest/python/pip_utils_tests.py
+++ b/src/unittest/python/pip_utils_tests.py
@@ -20,26 +20,26 @@ import os
 import unittest
 
 from pybuilder import core
-from pybuilder.pip_common import pip_version
 from pybuilder import pip_utils
+from pybuilder.pip_common import pip_version
 from test_utils import patch, ANY
 
 
 class PipVersionTests(unittest.TestCase):
     def test_pip_dependency_version(self):
-        self.assertEquals(pip_utils.build_dependency_version_string(core.Dependency("test", "1.2.3")), ">=1.2.3")
-        self.assertEquals(pip_utils.build_dependency_version_string(core.Dependency("test", ">=1.2.3,<=2.3.4")),
-                          "<=2.3.4,>=1.2.3")
-        self.assertEquals(pip_utils.build_dependency_version_string("1.2.3"), "1.2.3")
-        self.assertEquals(pip_utils.build_dependency_version_string(None), "")
+        self.assertEqual(pip_utils.build_dependency_version_string(core.Dependency("test", "1.2.3")), ">=1.2.3")
+        self.assertEqual(pip_utils.build_dependency_version_string(core.Dependency("test", ">=1.2.3,<=2.3.4")),
+                         "<=2.3.4,>=1.2.3")
+        self.assertEqual(pip_utils.build_dependency_version_string("1.2.3"), "1.2.3")
+        self.assertEqual(pip_utils.build_dependency_version_string(None), "")
 
     def test_version_satisfies_spec(self):
-        self.assertEquals(pip_utils.version_satisfies_spec(None, "blah"), True)
-        self.assertEquals(pip_utils.version_satisfies_spec("blah", None), False)
-        self.assertEquals(pip_utils.version_satisfies_spec(">=1.2.3", "1.2.4"), True)
-        self.assertEquals(pip_utils.version_satisfies_spec(">=1.2.3", "1.2.4.dev987"), False)
-        self.assertEquals(pip_utils.version_satisfies_spec(">=1.0", "1.1.dev1"), False)
-        self.assertEquals(pip_utils.version_satisfies_spec(">=1.0,>=0.0.dev0", "1.1.dev1"), True)
+        self.assertEqual(pip_utils.version_satisfies_spec(None, "blah"), True)
+        self.assertEqual(pip_utils.version_satisfies_spec("blah", None), False)
+        self.assertEqual(pip_utils.version_satisfies_spec(">=1.2.3", "1.2.4"), True)
+        self.assertEqual(pip_utils.version_satisfies_spec(">=1.2.3", "1.2.4.dev987"), False)
+        self.assertEqual(pip_utils.version_satisfies_spec(">=1.0", "1.1.dev1"), False)
+        self.assertEqual(pip_utils.version_satisfies_spec(">=1.0,>=0.0.dev0", "1.1.dev1"), True)
 
     def test_get_package_version(self):
         # Single item
@@ -60,7 +60,7 @@ class PipVersionTests(unittest.TestCase):
         multiple_identical_items = pip_utils.get_package_version(
             ["pip", core.Dependency("pip")])
         self.assertTrue("pip" in multiple_identical_items)
-        self.assertEquals(len(multiple_identical_items), 1)
+        self.assertEqual(len(multiple_identical_items), 1)
 
         # Validate case
         lower_case_packages = pip_utils.get_package_version("PiP")
@@ -69,30 +69,30 @@ class PipVersionTests(unittest.TestCase):
         self.assertTrue("PiP" not in lower_case_packages)
 
     def test_build_pip_install_options(self):
-        self.assertEquals(pip_utils.build_pip_install_options(), [])
-        self.assertEquals(pip_utils.build_pip_install_options(index_url="foo"), ["--index-url", "foo"])
-        self.assertEquals(pip_utils.build_pip_install_options(extra_index_url="foo"), ["--extra-index-url", "foo"])
-        self.assertEquals(pip_utils.build_pip_install_options(index_url="foo", extra_index_url="bar"),
-                          ["--index-url", "foo", "--extra-index-url", "bar"])
-        self.assertEquals(pip_utils.build_pip_install_options(extra_index_url=("foo", "bar")),
-                          ["--extra-index-url", "foo", "--extra-index-url", "bar"])
-        self.assertEquals(pip_utils.build_pip_install_options(trusted_host="foo"),
-                          ["--trusted-host", "foo"])
-        self.assertEquals(pip_utils.build_pip_install_options(trusted_host=("foo", "bar")),
-                          ["--trusted-host", "foo", "--trusted-host", "bar"])
-        self.assertEquals(pip_utils.build_pip_install_options(upgrade=True),
-                          ["--upgrade"] if pip_version < "9.0" else
-                          ["--upgrade", "--upgrade-strategy", "only-if-needed"])
-        self.assertEquals(pip_utils.build_pip_install_options(upgrade=True, eager_upgrade=True),
-                          ["--upgrade"] if pip_version < "9.0" else
-                          ["--upgrade", "--upgrade-strategy", "eager"])
-        self.assertEquals(pip_utils.build_pip_install_options(verbose=True), ["--verbose"])
-        self.assertEquals(pip_utils.build_pip_install_options(force_reinstall=True), ["--force-reinstall"])
-        self.assertEquals(pip_utils.build_pip_install_options(target_dir="target dir"), ["-t", "target dir"])
-        self.assertEquals(pip_utils.build_pip_install_options(target_dir="target dir"), ["-t", "target dir"])
-        self.assertEquals(pip_utils.build_pip_install_options(constraint_file="constraint file"),
-                          ["-c", "constraint file"])
-        self.assertEquals(pip_utils.build_pip_install_options(insecure_installs=["foo", "bar"]), [
+        self.assertEqual(pip_utils.build_pip_install_options(), [])
+        self.assertEqual(pip_utils.build_pip_install_options(index_url="foo"), ["--index-url", "foo"])
+        self.assertEqual(pip_utils.build_pip_install_options(extra_index_url="foo"), ["--extra-index-url", "foo"])
+        self.assertEqual(pip_utils.build_pip_install_options(index_url="foo", extra_index_url="bar"),
+                         ["--index-url", "foo", "--extra-index-url", "bar"])
+        self.assertEqual(pip_utils.build_pip_install_options(extra_index_url=("foo", "bar")),
+                         ["--extra-index-url", "foo", "--extra-index-url", "bar"])
+        self.assertEqual(pip_utils.build_pip_install_options(trusted_host="foo"),
+                         ["--trusted-host", "foo"])
+        self.assertEqual(pip_utils.build_pip_install_options(trusted_host=("foo", "bar")),
+                         ["--trusted-host", "foo", "--trusted-host", "bar"])
+        self.assertEqual(pip_utils.build_pip_install_options(upgrade=True),
+                         ["--upgrade"] if pip_version < "9.0" else
+                         ["--upgrade", "--upgrade-strategy", "only-if-needed"])
+        self.assertEqual(pip_utils.build_pip_install_options(upgrade=True, eager_upgrade=True),
+                         ["--upgrade"] if pip_version < "9.0" else
+                         ["--upgrade", "--upgrade-strategy", "eager"])
+        self.assertEqual(pip_utils.build_pip_install_options(verbose=True), ["--verbose"])
+        self.assertEqual(pip_utils.build_pip_install_options(force_reinstall=True), ["--force-reinstall"])
+        self.assertEqual(pip_utils.build_pip_install_options(target_dir="target dir"), ["-t", "target dir"])
+        self.assertEqual(pip_utils.build_pip_install_options(target_dir="target dir"), ["-t", "target dir"])
+        self.assertEqual(pip_utils.build_pip_install_options(constraint_file="constraint file"),
+                         ["-c", "constraint file"])
+        self.assertEqual(pip_utils.build_pip_install_options(insecure_installs=["foo", "bar"]), [
             "--allow-unverified", "foo",
             "--allow-external", "foo",
             "--allow-unverified", "bar",

--- a/src/unittest/python/pluginloader_tests.py
+++ b/src/unittest/python/pluginloader_tests.py
@@ -85,7 +85,7 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         plugin = downloader.load_plugin(project, "pypi:external_plugin")
 
         load.assert_called_with("external_plugin", "pypi:external_plugin")
-        self.assertEquals(plugin, load.return_value)
+        self.assertEqual(plugin, load.return_value)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -95,7 +95,7 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         self.assertRaises(MissingPluginException, downloader.load_plugin, Mock(), "pypi:external_plugin")
 
-        self.assertEquals(load.call_count, 1)
+        self.assertEqual(load.call_count, 1)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -105,7 +105,7 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         self.assertRaises(MissingPluginException, downloader.load_plugin, Mock(), "vcs:external_plugin URL",
                           plugin_module_name="vcs_module_name")
-        self.assertEquals(load.call_count, 1)
+        self.assertEqual(load.call_count, 1)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -130,7 +130,7 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         plugin = downloader.load_plugin(project, "vcs:external_plugin URL", plugin_module_name="external_plugin_module")
 
         load.assert_called_with("external_plugin_module", "vcs:external_plugin URL")
-        self.assertEquals(plugin, load.return_value)
+        self.assertEqual(plugin, load.return_value)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -150,10 +150,10 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         load.return_value = Mock()
 
-        self.assertEquals(load.return_value, downloader.load_plugin(project, "spam"))
+        self.assertEqual(load.return_value, downloader.load_plugin(project, "spam"))
 
         install.assert_not_called()
-        self.assertEquals(install.call_count, 0)
+        self.assertEqual(install.call_count, 0)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -162,10 +162,10 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         load.return_value = Mock()
 
-        self.assertEquals(load.return_value, downloader.load_plugin(project, "vcs:spam", plugin_module_name="spam"))
+        self.assertEqual(load.return_value, downloader.load_plugin(project, "vcs:spam", plugin_module_name="spam"))
 
         install.assert_called_with(project, "vcs:spam", None, downloader.logger, "spam", False, True)
-        self.assertEquals(install.call_count, 1)
+        self.assertEqual(install.call_count, 1)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -174,10 +174,10 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         load.return_value = Mock()
 
-        self.assertEquals(load.return_value, downloader.load_plugin(project, "pypi:spam", ">1.2"))
+        self.assertEqual(load.return_value, downloader.load_plugin(project, "pypi:spam", ">1.2"))
 
         install.assert_called_with(project, "pypi:spam", ">1.2", downloader.logger, None, True, False)
-        self.assertEquals(install.call_count, 1)
+        self.assertEqual(install.call_count, 1)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -187,10 +187,10 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         downloader = DownloadingPluginLoader(Mock())
         load.return_value = Mock()
 
-        self.assertEquals(load.return_value, downloader.load_plugin(project, "pypi:spam", ">1.2,==1.4"))
+        self.assertEqual(load.return_value, downloader.load_plugin(project, "pypi:spam", ">1.2,==1.4"))
 
         install.assert_called_with(project, "pypi:spam", ">1.2,==1.4", downloader.logger, None, True, False)
-        self.assertEquals(install.call_count, 1)
+        self.assertEqual(install.call_count, 1)
 
     @patch("pybuilder.pluginloader._load_plugin")
     @patch("pybuilder.pluginloader._install_external_plugin")
@@ -200,10 +200,10 @@ class DownloadingPluginLoaderTest(unittest.TestCase):
         plugin = Mock()
         load.side_effect = (MissingPluginException("no spam installed"), plugin)
 
-        self.assertEquals(plugin, downloader.load_plugin(project, "pypi:spam", "===1.4"))
+        self.assertEqual(plugin, downloader.load_plugin(project, "pypi:spam", "===1.4"))
 
         install.assert_called_with(project, "pypi:spam", "===1.4", downloader.logger, None)
-        self.assertEquals(install.call_count, 1)
+        self.assertEqual(install.call_count, 1)
 
 
 class InstallExternalPluginTests(unittest.TestCase):
@@ -312,7 +312,7 @@ class BuiltinPluginLoaderTest(unittest.TestCase):
         plugin_module = self.loader.load_plugin(self.project, "spam")
 
         load.assert_called_with("pybuilder.plugins.spam_plugin", "spam")
-        self.assertEquals(load.return_value, plugin_module)
+        self.assertEqual(load.return_value, plugin_module)
 
 
 class DispatchingPluginLoaderTest(unittest.TestCase):
@@ -339,7 +339,7 @@ class DispatchingPluginLoaderTest(unittest.TestCase):
         self.first_delegatee.load_plugin.side_effect = MissingPluginException("spam")
         self.second_delegatee.load_plugin.return_value = result
 
-        self.assertEquals(result, self.loader.load_plugin(self.project, "spam"))
+        self.assertEqual(result, self.loader.load_plugin(self.project, "spam"))
 
         self.first_delegatee.load_plugin.assert_called_with(self.project, "spam", None, None)
         self.second_delegatee.load_plugin.assert_called_with(self.project, "spam", None, None)
@@ -348,7 +348,7 @@ class DispatchingPluginLoaderTest(unittest.TestCase):
         result = "result"
         self.first_delegatee.load_plugin.return_value = result
 
-        self.assertEquals(result, self.loader.load_plugin(self.project, "spam"))
+        self.assertEqual(result, self.loader.load_plugin(self.project, "spam"))
 
         self.first_delegatee.load_plugin.assert_called_with(self.project, "spam", None, None)
         self.second_delegatee.load_plugin.assert_not_called()

--- a/src/unittest/python/plugins/filter_resources_plugin_tests.py
+++ b/src/unittest/python/plugins/filter_resources_plugin_tests.py
@@ -28,7 +28,7 @@ class ProjectDictWrapperTest(unittest.TestCase):
         project_mock = Mock(Project)
         project_mock.name = "my name"
 
-        self.assertEquals("my name", ProjectDictWrapper(project_mock, Mock())["name"])
+        self.assertEqual("my name", ProjectDictWrapper(project_mock, Mock())["name"])
 
         project_mock.get_property.assert_not_called()
 
@@ -37,7 +37,7 @@ class ProjectDictWrapperTest(unittest.TestCase):
         project_mock.has_property = Mock(return_value=True)
         project_mock.get_property = Mock(return_value="eggs")
 
-        self.assertEquals("eggs", ProjectDictWrapper(project_mock, Mock())["spam"])
+        self.assertEqual("eggs", ProjectDictWrapper(project_mock, Mock())["spam"])
 
         project_mock.get_property.assert_called_with("spam")
 
@@ -47,7 +47,7 @@ class ProjectDictWrapperTest(unittest.TestCase):
         project_mock.has_property = Mock(return_value=False)
         project_mock.get_property = Mock()
 
-        self.assertEquals("${n/a}", ProjectDictWrapper(project_mock, logger_mock)["n/a"])
+        self.assertEqual("${n/a}", ProjectDictWrapper(project_mock, logger_mock)["n/a"])
 
         project_mock.get_property.assert_not_called()
         logger_mock.warn.assert_called_with(

--- a/src/unittest/python/plugins/python/core_plugin_tests.py
+++ b/src/unittest/python/plugins/python/core_plugin_tests.py
@@ -19,18 +19,16 @@
 import unittest
 from os.path import join
 
-from test_utils import patch
-
-from pybuilder.plugins.python.core_plugin import init_python_directories
+from pybuilder.core import Project
 from pybuilder.plugins.python.core_plugin import (DISTRIBUTION_PROPERTY,
                                                   PYTHON_SOURCES_PROPERTY,
                                                   SCRIPTS_SOURCES_PROPERTY,
                                                   SCRIPTS_TARGET_PROPERTY)
-from pybuilder.core import Project
+from pybuilder.plugins.python.core_plugin import init_python_directories
+from test_utils import patch
 
 
-class InitPythonDirectoriesTest (unittest.TestCase):
-
+class InitPythonDirectoriesTest(unittest.TestCase):
     def greedy(self, generator):
         return [element for element in generator]
 
@@ -44,7 +42,7 @@ class InitPythonDirectoriesTest (unittest.TestCase):
 
         init_python_directories(self.project)
 
-        self.assertEquals(
+        self.assertEqual(
             ['foo', 'bar'],
             self.greedy(self.project.list_modules())
         )
@@ -61,7 +59,7 @@ class InitPythonDirectoriesTest (unittest.TestCase):
 
         init_python_directories(self.project)
 
-        self.assertEquals(
+        self.assertEqual(
             ['pybuilder.pluginhelper',
              'pybuilder.plugins'],
             self.greedy(self.project.list_packages())
@@ -79,7 +77,7 @@ class InitPythonDirectoriesTest (unittest.TestCase):
 
         init_python_directories(self.project)
 
-        self.assertEquals(
+        self.assertEqual(
             ['pybuilder.pluginhelper',
              'pybuilder.plugins'],
             self.greedy(self.project.list_packages())
@@ -87,20 +85,20 @@ class InitPythonDirectoriesTest (unittest.TestCase):
 
     def test_should_set_python_sources_property(self):
         init_python_directories(self.project)
-        self.assertEquals(
+        self.assertEqual(
             "src/main/python", self.project.get_property(PYTHON_SOURCES_PROPERTY, "caboom"))
 
     def test_should_set_scripts_sources_property(self):
         init_python_directories(self.project)
-        self.assertEquals(
+        self.assertEqual(
             "src/main/scripts", self.project.get_property(SCRIPTS_SOURCES_PROPERTY, "caboom"))
 
     def test_should_set_dist_scripts_property(self):
         init_python_directories(self.project)
-        self.assertEquals(
+        self.assertEqual(
             "scripts", self.project.get_property(SCRIPTS_TARGET_PROPERTY))
 
     def test_should_set_dist_property(self):
         init_python_directories(self.project)
-        self.assertEquals("$dir_target/dist/.-1.0.dev0",
-                          self.project.get_property(DISTRIBUTION_PROPERTY, "caboom"))
+        self.assertEqual("$dir_target/dist/.-1.0.dev0",
+                         self.project.get_property(DISTRIBUTION_PROPERTY, "caboom"))

--- a/src/unittest/python/plugins/python/coverage_plugin_tests.py
+++ b/src/unittest/python/plugins/python/coverage_plugin_tests.py
@@ -55,13 +55,13 @@ class CoveragePluginTests(TestCase):
             init_coverage_properties(self.project)
 
         for property_name, property_value in expected_properties.items():
-            self.assertEquals(self.project.get_property("coverage_threshold_warn"), 120)
-            self.assertEquals(self.project.get_property("coverage_branch_threshold_warn"), 120)
-            self.assertEquals(self.project.get_property("coverage_branch_partial_threshold_warn"), 120)
-            self.assertEquals(self.project.get_property("coverage_break_build"), False)
-            self.assertEquals(self.project.get_property("coverage_reload_modules"), False)
-            self.assertEquals(self.project.get_property("coverage_exceptions"), ["foo"])
-            self.assertEquals(self.project.get_property("coverage_fork"), True)
+            self.assertEqual(self.project.get_property("coverage_threshold_warn"), 120)
+            self.assertEqual(self.project.get_property("coverage_branch_threshold_warn"), 120)
+            self.assertEqual(self.project.get_property("coverage_branch_partial_threshold_warn"), 120)
+            self.assertEqual(self.project.get_property("coverage_break_build"), False)
+            self.assertEqual(self.project.get_property("coverage_reload_modules"), False)
+            self.assertEqual(self.project.get_property("coverage_exceptions"), ["foo"])
+            self.assertEqual(self.project.get_property("coverage_fork"), True)
 
     def test_list_all_covered_modules_all_loaded(self):
         module_a_val = MagicMock(__name__='module_a', __file__='module_a.py')
@@ -71,7 +71,7 @@ class CoveragePluginTests(TestCase):
                 returned_modules, non_imported_modules = _list_all_covered_modules(MagicMock(),
                                                                                    ['module_a', 'module_b'], [], True)
 
-        self.assertEquals([module_a_val, module_b_val], returned_modules)
+        self.assertEqual([module_a_val, module_b_val], returned_modules)
         import_func.assert_not_called()
 
     def test_list_all_covered_modules_not_imported(self):
@@ -83,8 +83,8 @@ class CoveragePluginTests(TestCase):
                 returned_modules, non_imported_modules = _list_all_covered_modules(MagicMock(),
                                                                                    ['module_a', 'module_b'], [], False)
 
-        self.assertEquals([module_a_val, module_b_val], returned_modules)
-        self.assertEquals([module_b_val.__name__], non_imported_modules)
+        self.assertEqual([module_a_val, module_b_val], returned_modules)
+        self.assertEqual([module_b_val.__name__], non_imported_modules)
         import_func.assert_called_once_with('module_b')
 
     def test_list_all_covered_modules_load(self):
@@ -96,7 +96,7 @@ class CoveragePluginTests(TestCase):
                 returned_modules, non_imported_modules = _list_all_covered_modules(MagicMock(),
                                                                                    ['module_a', 'module_b'], [], True)
 
-        self.assertEquals([module_a_val, module_b_val], returned_modules)
+        self.assertEqual([module_a_val, module_b_val], returned_modules)
         import_func.assert_called_once_with('module_b')
 
     def test_list_all_covered_modules_duplicate(self):
@@ -108,7 +108,7 @@ class CoveragePluginTests(TestCase):
                                                                                    ['module_a', 'module_b', 'module_a'],
                                                                                    [], True)
 
-        self.assertEquals([module_a_val, module_b_val], returned_modules)
+        self.assertEqual([module_a_val, module_b_val], returned_modules)
         import_func.assert_not_called()
 
     def test_list_all_covered_modules_exclusions(self):
@@ -121,7 +121,7 @@ class CoveragePluginTests(TestCase):
                                                                                    ['module_a', 'module_b', 'module_c'],
                                                                                    ['module_c'], True)
 
-        self.assertEquals([module_a_val, module_b_val], returned_modules)
+        self.assertEqual([module_a_val, module_b_val], returned_modules)
         import_func.assert_not_called()
         logger.debug.assert_called_with("Module '%s' was excluded", 'module_c')
 
@@ -138,9 +138,9 @@ class CoveragePluginTests(TestCase):
         n.n_missing_branches = 0
 
         report = _build_module_report(coverage, MagicMock())
-        self.assertEquals(report.code_coverage, 100)
-        self.assertEquals(report.branch_coverage, 100)
-        self.assertEquals(report.branch_partial_coverage, 100)
+        self.assertEqual(report.code_coverage, 100)
+        self.assertEqual(report.branch_coverage, 100)
+        self.assertEqual(report.branch_partial_coverage, 100)
 
     @patch('coverage.results.Analysis')
     @patch('coverage.coverage')
@@ -155,9 +155,9 @@ class CoveragePluginTests(TestCase):
         n.n_missing_branches = 10
 
         report = _build_module_report(coverage, MagicMock())
-        self.assertEquals(report.code_coverage, 0)
-        self.assertEquals(report.branch_coverage, 0)
-        self.assertEquals(report.branch_partial_coverage, 0)
+        self.assertEqual(report.code_coverage, 0)
+        self.assertEqual(report.branch_coverage, 0)
+        self.assertEqual(report.branch_partial_coverage, 0)
 
     @patch('coverage.results.Analysis')
     @patch('coverage.coverage')
@@ -172,9 +172,9 @@ class CoveragePluginTests(TestCase):
         n.n_missing_branches = 5
 
         report = _build_module_report(coverage, MagicMock())
-        self.assertEquals(report.code_coverage, 50)
-        self.assertEquals(report.branch_coverage, 50)
-        self.assertEquals(report.branch_partial_coverage, 50)
+        self.assertEqual(report.code_coverage, 50)
+        self.assertEqual(report.branch_coverage, 50)
+        self.assertEqual(report.branch_partial_coverage, 50)
 
     @patch('coverage.coverage')
     def test_build_coverage_report_no_modules(self, coverage):
@@ -226,6 +226,6 @@ class CoveragePluginTests(TestCase):
         self.assertTrue(_build_coverage_report(project, MagicMock(Logger), execution_name, execution_prefix, coverage,
                                                modules) is None)
         report = render_report.call_args[0][0]
-        self.assertEquals(report['overall_coverage'], 50)
-        self.assertEquals(report['overall_branch_coverage'], 50)
-        self.assertEquals(report['overall_branch_partial_coverage'], 50)
+        self.assertEqual(report['overall_coverage'], 50)
+        self.assertEqual(report['overall_branch_coverage'], 50)
+        self.assertEqual(report['overall_branch_partial_coverage'], 50)

--- a/src/unittest/python/plugins/python/distutils_plugin_tests.py
+++ b/src/unittest/python/plugins/python/distutils_plugin_tests.py
@@ -703,7 +703,8 @@ class ExecuteDistUtilsTest(PyBuilderTestCase):
     def test__run_process_and_wait(self, popen):
         commands = ["a", "b", "c"]
         _run_process_and_wait(commands, "test cwd", "test stdout", "test_stderr")
-        popen.assert_called_with(commands, cwd="test cwd", stdout="test stdout", stderr="test_stderr", shell=False)
+        popen.assert_called_with(commands, cwd="test cwd", stdin=ANY, stdout="test stdout", stderr="test_stderr",
+                                 shell=False)
 
 
 class UploadTests(PyBuilderTestCase):

--- a/src/unittest/python/plugins/python/flake8_plugin_tests.py
+++ b/src/unittest/python/plugins/python/flake8_plugin_tests.py
@@ -31,17 +31,17 @@ class FlakePluginInitializationTests(TestCase):
             initialize_flake8_plugin(self.project)
 
         for property_name, property_value in expected_properties.items():
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_break_build"), True)
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_max_line_length"), 80)
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_include_patterns"), "*.py")
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_exclude_patterns"), ".svn")
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_include_test_sources"), True)
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_include_scripts"), True)
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("flake8_max_complexity"), 10)

--- a/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/integrationtest_plugin_tests.py
@@ -55,15 +55,15 @@ class TaskPoolProgressTests(unittest.TestCase):
             initialize_integrationtest_plugin(self.project)
 
         for property_name, property_value in expected_properties.items():
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("dir_source_integrationtest_python"), "foo/bar/python")
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("integrationtest_file_glob"), "*foo.py")
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("integrationtest_file_suffix"), True)
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("integrationtest_additional_environment"), {"env3": "foo"}),
-            self.assertEquals(
+            self.assertEqual(
                 self.project.get_property("integrationtest_always_verbose"), True)
 
     def test_should_create_new_progress(self):

--- a/src/unittest/python/plugins/python/pdoc_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pdoc_plugin_tests.py
@@ -42,13 +42,13 @@ class PdocPluginTests(unittest.TestCase):
 
         os_path_exists.return_value = False
         pdoc_prepare(self.project, self.logger)
-        self.assertEquals(os_mkdir.call_count, 1)
+        self.assertEqual(os_mkdir.call_count, 1)
 
         os_path_exists.return_value = True
         pdoc_prepare(self.project, self.logger)
-        self.assertEquals(os_mkdir.call_count, 1)
+        self.assertEqual(os_mkdir.call_count, 1)
 
-        self.assertEquals(assert_can_exec.call_count, 2)
+        self.assertEqual(assert_can_exec.call_count, 2)
 
     @patch("pybuilder.plugins.python.pdoc_plugin.os.mkdir")
     @patch("pybuilder.plugins.python.pdoc_plugin.os.path.exists")

--- a/src/unittest/python/plugins/python/pychecker_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pychecker_plugin_tests.py
@@ -31,7 +31,7 @@ class PycheckerWarningTest(unittest.TestCase):
             "message": "any message",
             "line_number": 17
         }
-        self.assertEquals(
+        self.assertEqual(
             expected, PycheckerWarning("any message", 17).to_json_dict())
 
 
@@ -46,7 +46,7 @@ class PycheckerModuleReportTest(unittest.TestCase):
             "warnings": [{"message": "warning 1", "line_number": 1},
                          {"message": "warning 2", "line_number": 2}]
         }
-        self.assertEquals(expected, report.to_json_dict())
+        self.assertEqual(expected, report.to_json_dict())
 
 
 class PycheckerReportTest(unittest.TestCase):
@@ -78,7 +78,7 @@ class PycheckerReportTest(unittest.TestCase):
             ]
         }
 
-        self.assertEquals(expected, report.to_json_dict())
+        self.assertEqual(expected, report.to_json_dict())
 
 
 class ParsePycheckerOutputTest(unittest.TestCase):
@@ -96,23 +96,23 @@ class ParsePycheckerOutputTest(unittest.TestCase):
 
         report = parse_pychecker_output(project, warnings)
 
-        self.assertEquals(2, len(report.module_reports))
+        self.assertEqual(2, len(report.module_reports))
 
-        self.assertEquals("package.module_one", report.module_reports[0].name)
-        self.assertEquals(2, len(report.module_reports[0].warnings))
-        self.assertEquals(
+        self.assertEqual("package.module_one", report.module_reports[0].name)
+        self.assertEqual(2, len(report.module_reports[0].warnings))
+        self.assertEqual(
             "Sample warning", report.module_reports[0].warnings[0].message)
-        self.assertEquals(2, report.module_reports[0].warnings[0].line_number)
-        self.assertEquals("Another sample warning",
-                          report.module_reports[0].warnings[1].message)
-        self.assertEquals(4, report.module_reports[0].warnings[1].line_number)
+        self.assertEqual(2, report.module_reports[0].warnings[0].line_number)
+        self.assertEqual("Another sample warning",
+                         report.module_reports[0].warnings[1].message)
+        self.assertEqual(4, report.module_reports[0].warnings[1].line_number)
 
-        self.assertEquals("package.module_two", report.module_reports[1].name)
-        self.assertEquals(2, len(report.module_reports[1].warnings))
-        self.assertEquals("Another sample warning",
-                          report.module_reports[1].warnings[0].message)
-        self.assertEquals(33, report.module_reports[1].warnings[0].line_number)
-        self.assertEquals("Yet another sample warning",
-                          report.module_reports[1].warnings[1].message)
-        self.assertEquals(
+        self.assertEqual("package.module_two", report.module_reports[1].name)
+        self.assertEqual(2, len(report.module_reports[1].warnings))
+        self.assertEqual("Another sample warning",
+                         report.module_reports[1].warnings[0].message)
+        self.assertEqual(33, report.module_reports[1].warnings[0].line_number)
+        self.assertEqual("Yet another sample warning",
+                         report.module_reports[1].warnings[1].message)
+        self.assertEqual(
             332, report.module_reports[1].warnings[1].line_number)

--- a/src/unittest/python/plugins/python/pyfix_unittest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pyfix_unittest_plugin_tests.py
@@ -17,17 +17,15 @@
 #   limitations under the License.
 
 from unittest import TestCase
-from test_utils import Mock, call, patch
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.pyfix_unittest_plugin import init_test_source_directory
+from test_utils import Mock, call, patch
 
 
 class InitTestSourceDirectoryTests(TestCase):
-
     @patch('pybuilder.plugins.python.pyfix_plugin_impl.execute_tests_matching')
     def test_should_set_pyfix_dependency(self, mock_execute_tests_matching):
-
         mock_project = Mock(Project)
 
         init_test_source_directory(mock_project)
@@ -36,12 +34,11 @@ class InitTestSourceDirectoryTests(TestCase):
 
     @patch('pybuilder.plugins.python.pyfix_plugin_impl.execute_tests_matching')
     def test_should_set_default_properties(self, mock_execute_tests_matching):
-
         mock_project = Mock(Project)
 
         init_test_source_directory(mock_project)
 
-        self.assertEquals(mock_project.set_property_if_unset.call_args_list,
-                          [call('dir_source_unittest_python', 'src/unittest/python'),
-                           call('pyfix_unittest_module_glob', '*_pyfix_tests'),
-                           call('pyfix_unittest_file_suffix', None)])
+        self.assertEqual(mock_project.set_property_if_unset.call_args_list,
+                         [call('dir_source_unittest_python', 'src/unittest/python'),
+                          call('pyfix_unittest_module_glob', '*_pyfix_tests'),
+                          call('pyfix_unittest_file_suffix', None)])

--- a/src/unittest/python/plugins/python/python_plugin_helper_tests.py
+++ b/src/unittest/python/plugins/python/python_plugin_helper_tests.py
@@ -18,13 +18,12 @@
 
 import unittest
 
-from test_utils import Mock, call, patch
-
 from pybuilder.plugins.python.python_plugin_helper import (log_report,
                                                            discover_affected_files,
                                                            discover_affected_dirs,
                                                            execute_tool_on_source_files,
                                                            _if_property_set_and_dir_exists)
+from test_utils import Mock, call, patch
 
 
 class LogReportsTest(unittest.TestCase):
@@ -153,15 +152,15 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_unittest_python'),
                           call('dir_source_integrationtest_python'),
                           call('dir_source_integrationtest_python')])
-        self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_unittest_python', 'dir_source_integrationtest_python'])
+        self.assertEqual(files,
+                         ['dir_source_main_python', 'dir_source_unittest_python', 'dir_source_integrationtest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_test_sources_are_included_no_unittests(self, _):
         project = Mock()
 
-        project.get_property.side_effect = lambda \
-            _property: _property if _property != 'dir_source_unittest_python' else None
+        project.get_property.side_effect = lambda _property: (
+            _property if _property != 'dir_source_unittest_python' else None)
 
         files = discover_affected_dirs(True, False, project)
 
@@ -170,15 +169,15 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_unittest_python'),
                           call('dir_source_integrationtest_python'),
                           call('dir_source_integrationtest_python')])
-        self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_integrationtest_python'])
+        self.assertEqual(files,
+                         ['dir_source_main_python', 'dir_source_integrationtest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_test_sources_are_included_no_integrationtests(self, _):
         project = Mock()
 
-        project.get_property.side_effect = lambda \
-            _property: _property if _property != 'dir_source_integrationtest_python' else None
+        project.get_property.side_effect = lambda _property: (
+            _property if _property != 'dir_source_integrationtest_python' else None)
 
         files = discover_affected_dirs(True, False, project)
 
@@ -187,15 +186,15 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                           call('dir_source_unittest_python'),
                           call('dir_source_unittest_python'),
                           call('dir_source_integrationtest_python')])
-        self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_unittest_python'])
+        self.assertEqual(files,
+                         ['dir_source_main_python', 'dir_source_unittest_python'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_should_discover_source_dirs_when_script_sources_are_included(self, _):
         project = Mock()
 
-        project.get_property.side_effect = lambda \
-            _property: _property if _property != 'dir_source_integrationtest_python' else None
+        project.get_property.side_effect = lambda _property: (
+            _property if _property != 'dir_source_integrationtest_python' else None)
 
         files = discover_affected_dirs(False, True, project)
 
@@ -203,8 +202,8 @@ class DiscoverAffectedDirsTest(unittest.TestCase):
                          [call('dir_source_main_python'),
                           call('dir_source_main_scripts'),
                           call('dir_source_main_scripts')])
-        self.assertEquals(files,
-                          ['dir_source_main_python', 'dir_source_main_scripts'])
+        self.assertEqual(files,
+                         ['dir_source_main_python', 'dir_source_main_scripts'])
 
     @patch('pybuilder.plugins.python.python_plugin_helper.os.path.isdir', return_value=True)
     def test_if_property_set_and_dir_exists(self, exists):

--- a/src/unittest/python/plugins/python/sphinx_plugin_tests.py
+++ b/src/unittest/python/plugins/python/sphinx_plugin_tests.py
@@ -79,7 +79,7 @@ class SphinxPluginInitializationTests(TestCase):
             initialize_sphinx_plugin(self.project)
 
         for property_name, property_value in expected_properties.items():
-            self.assertEquals(
+            self.assertEqual(
 
                 self.project.get_property(property_name),
                 property_value)
@@ -93,19 +93,19 @@ class SphinxPluginInitializationTests(TestCase):
         self.project.set_property("sphinx_project_name", "foo")
         self.project.set_property("sphinx_project_version", "1.0")
 
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_source_dir"), "docs")
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_output_dir"), "docs/_build/")
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_config_path"), "docs")
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_doc_author"), 'John Doe, Jane Doe')
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_doc_builder"), "html")
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_project_name"), "foo")
-        self.assertEquals(
+        self.assertEqual(
             self.project.get_property("sphinx_project_version"), "1.0")
 
 
@@ -192,7 +192,7 @@ class SphinxBuildCommandTests(TestCase):
         initialize_sphinx_plugin(self.project)
 
         run_sphinx_build(["foo"], "bar", Mock(), self.project)
-        self.assertEquals(exec_command.call_count, 1)
+        self.assertEqual(exec_command.call_count, 1)
 
     def test_get_sphinx_apidoc_command_enabled(self):
         sphinx_mock = Mock()

--- a/src/unittest/python/plugins/python/unittest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/unittest_plugin_tests.py
@@ -241,16 +241,16 @@ class UnittestRunnerTest(TestCase):
         self.assertTrue(isinstance(_create_runner(("unittest.TextTestRunner", Mock())), TextTestRunner))
 
     def test_get_make_result_method_name_default(self):
-        self.assertEquals(_get_make_result_method_name(TextTestRunner), "_makeResult")
+        self.assertEqual(_get_make_result_method_name(TextTestRunner), "_makeResult")
 
     def test_get_make_result_method_name_from_str(self):
-        self.assertEquals(_get_make_result_method_name((TextTestRunner, "_makeResult")), "_makeResult")
+        self.assertEqual(_get_make_result_method_name((TextTestRunner, "_makeResult")), "_makeResult")
 
     def test_get_make_result_method_name_from_method(self):
-        self.assertEquals(_get_make_result_method_name((TextTestRunner, TextTestRunner._makeResult)), "_makeResult")
+        self.assertEqual(_get_make_result_method_name((TextTestRunner, TextTestRunner._makeResult)), "_makeResult")
 
     def test_get_make_result_method_name_from_func(self):
         def _makeResult(self):
             pass
 
-        self.assertEquals(_get_make_result_method_name((TextTestRunner, _makeResult)), "_makeResult")
+        self.assertEqual(_get_make_result_method_name((TextTestRunner, _makeResult)), "_makeResult")

--- a/src/unittest/python/plugins/ronn_manpage_plugin_tests.py
+++ b/src/unittest/python/plugins/ronn_manpage_plugin_tests.py
@@ -58,7 +58,7 @@ class RonnPluginInitializationTests(TestCase):
             init_ronn_manpage_plugin(self.project)
 
         for property_name, property_value in expected_properties.items():
-            self.assertEquals(
+            self.assertEqual(
 
                 self.project.get_property(property_name),
                 property_value)

--- a/src/unittest/python/reactor_tests.py
+++ b/src/unittest/python/reactor_tests.py
@@ -51,7 +51,7 @@ class ReactorTest(unittest.TestCase):
 
     def test_should_return_tasks_from_execution_manager_when_calling_get_tasks(self):
         self.execution_manager.tasks = ["spam"]
-        self.assertEquals(["spam"], self.reactor.get_tasks())
+        self.assertEqual(["spam"], self.reactor.get_tasks())
 
     def test_should_raise_exception_when_importing_plugin_and_plugin_not_found(self):
         self.plugin_loader_mock.load_plugin.side_effect = MissingPluginException("not_found")
@@ -72,10 +72,10 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 1)
+        self.assertEqual(len(self.execution_manager.register_task.call_args_list), 1)
         self.assertTrue(isinstance(self.execution_manager.register_task.call_args[0][0], Task) and len(
             self.execution_manager.register_task.call_args[0]) == 1)
-        self.assertEquals(self.execution_manager.register_task.call_args[0][0].name, "task")
+        self.assertEqual(self.execution_manager.register_task.call_args[0][0].name, "task")
 
     def test_should_collect_single_task_with_overridden_name(self):
         def task():
@@ -89,10 +89,10 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 1)
+        self.assertEqual(len(self.execution_manager.register_task.call_args_list), 1)
         self.assertTrue(isinstance(self.execution_manager.register_task.call_args[0][0], Task) and len(
             self.execution_manager.register_task.call_args[0]) == 1)
-        self.assertEquals(self.execution_manager.register_task.call_args[0][0].name, "overridden_name")
+        self.assertEqual(self.execution_manager.register_task.call_args[0][0].name, "overridden_name")
 
     def test_should_collect_multiple_tasks(self):
         def task():
@@ -111,7 +111,7 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(len(self.execution_manager.register_task.call_args_list), 2)
+        self.assertEqual(len(self.execution_manager.register_task.call_args_list), 2)
         for call_args in self.execution_manager.register_task.call_args_list:
             self.assertTrue(isinstance(call_args[0][0], Task) and len(call_args[0]) == 1)
 
@@ -247,7 +247,7 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(self.execution_manager.register_action.call_count, 1)
+        self.assertEqual(self.execution_manager.register_action.call_count, 1)
         self.assertTrue(isinstance(self.execution_manager.register_action.call_args[0][0], Action) and
                         len(self.execution_manager.register_action.call_args[0]) == 1)
 
@@ -261,7 +261,7 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(self.execution_manager.register_action.call_count, 1)
+        self.assertEqual(self.execution_manager.register_action.call_count, 1)
         self.assertTrue(isinstance(self.execution_manager.register_action.call_args[0][0], Action) and
                         len(self.execution_manager.register_action.call_args[0]) == 1)
 
@@ -302,7 +302,7 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(self.execution_manager.register_initializer.call_count, 1)
+        self.assertEqual(self.execution_manager.register_initializer.call_count, 1)
         self.assertTrue(isinstance(self.execution_manager.register_initializer.call_args[0][0], Initializer) and
                         len(self.execution_manager.register_initializer.call_args[0]) == 1)
 
@@ -328,7 +328,7 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.collect_tasks_and_actions_and_initializers(module)
 
-        self.assertEquals(
+        self.assertEqual(
             execution_manager_mock.initializer.environments, ["any_environment"])
 
     @patch("pybuilder.reactor.os.path.exists", return_value=False)
@@ -404,7 +404,7 @@ class ReactorTest(unittest.TestCase):
                                                                                                   os_path_isdir,
                                                                                                   os_path_join,
                                                                                                   os_path_isfile):
-        self.assertEquals(
+        self.assertEqual(
             ("/spam", "/spam/eggs"), self.reactor.verify_project_directory("spam", "eggs"))
 
         os_path_abspath.assert_called_with("spam")
@@ -443,14 +443,14 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.apply_project_attributes()
 
-        self.assertEquals("version", self.reactor.project.version)
-        self.assertEquals("default_task", self.reactor.project.default_task)
-        self.assertEquals("summary", self.reactor.project.summary)
-        self.assertEquals("home_page", self.reactor.project.home_page)
-        self.assertEquals("description", self.reactor.project.description)
-        self.assertEquals("authors", self.reactor.project.authors)
-        self.assertEquals("license", self.reactor.project.license)
-        self.assertEquals("url", self.reactor.project.url)
+        self.assertEqual("version", self.reactor.project.version)
+        self.assertEqual("default_task", self.reactor.project.default_task)
+        self.assertEqual("summary", self.reactor.project.summary)
+        self.assertEqual("home_page", self.reactor.project.home_page)
+        self.assertEqual("description", self.reactor.project.description)
+        self.assertEqual("authors", self.reactor.project.authors)
+        self.assertEqual("license", self.reactor.project.license)
+        self.assertEqual("url", self.reactor.project.url)
 
     def test_ensure_project_name_is_set_from_attribute_when_instantiating_project(self):
         module = ModuleType("mock_module")
@@ -460,7 +460,7 @@ class ReactorTest(unittest.TestCase):
         self.reactor.project_module = module
         self.reactor.apply_project_attributes()
 
-        self.assertEquals("mock_module", self.reactor.project.name)
+        self.assertEqual("mock_module", self.reactor.project.name)
 
     def test_should_import_plugin_only_once(self):
         plugin_module = ModuleType("mock_module")
@@ -469,7 +469,7 @@ class ReactorTest(unittest.TestCase):
         self.reactor.require_plugin("spam")
         self.reactor.require_plugin("spam")
 
-        self.assertEquals(["spam"], self.reactor.get_plugins())
+        self.assertEqual(["spam"], self.reactor.get_plugins())
 
         self.plugin_loader_mock.load_plugin.assert_called_with(ANY, "spam", None, None)
 
@@ -482,7 +482,7 @@ class ReactorTest(unittest.TestCase):
         self.reactor.log_project_properties()
 
         call_args = self.logger.debug.call_args
-        self.assertEquals(call_args[0][0], "Project properties: %s")
+        self.assertEqual(call_args[0][0], "Project properties: %s")
         self.assertTrue("basedir : spam" in call_args[0][1])
         self.assertTrue("eggs : eggs" in call_args[0][1])
         self.assertTrue("spam : spam" in call_args[0][1])
@@ -498,26 +498,26 @@ class ReactorTest(unittest.TestCase):
 
         self.reactor.project.default_task = ["a", "b"]
 
-        self.assertEquals(self.reactor._prepare_tasks(["c"]), ["c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c"]), ["a", "b", "c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", '^c']), ["a", "b"])
-        self.assertEquals(self.reactor._prepare_tasks(["^b"]), ["a"])
-        self.assertEquals(self.reactor._prepare_tasks(["^a"]), ["b"])
-        self.assertEquals(self.reactor._prepare_tasks(["^d"]), ["a", "b"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "d"]), ["d", "c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "d", "^b"]), ["d", "c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "+", "^"]), ["+", "^", "c"])
-        self.assertEquals(self.reactor._prepare_tasks([]), ["a", "b"])
+        self.assertEqual(self.reactor._prepare_tasks(["c"]), ["c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c"]), ["a", "b", "c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", '^c']), ["a", "b"])
+        self.assertEqual(self.reactor._prepare_tasks(["^b"]), ["a"])
+        self.assertEqual(self.reactor._prepare_tasks(["^a"]), ["b"])
+        self.assertEqual(self.reactor._prepare_tasks(["^d"]), ["a", "b"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "d"]), ["d", "c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "d", "^b"]), ["d", "c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "+", "^"]), ["+", "^", "c"])
+        self.assertEqual(self.reactor._prepare_tasks([]), ["a", "b"])
 
         self.reactor.project.default_task = []
 
-        self.assertEquals(self.reactor._prepare_tasks(["c"]), ["c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c"]), ["c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "^d"]), ["c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "d", "^d"]), ["c"])
-        self.assertEquals(self.reactor._prepare_tasks(["^c", "c"]), [])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "^c"]), [])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "d"]), ["d", "c"])
-        self.assertEquals(self.reactor._prepare_tasks(["+c", "+"]), ["+", "c"])
+        self.assertEqual(self.reactor._prepare_tasks(["c"]), ["c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c"]), ["c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "^d"]), ["c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "d", "^d"]), ["c"])
+        self.assertEqual(self.reactor._prepare_tasks(["^c", "c"]), [])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "^c"]), [])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "d"]), ["d", "c"])
+        self.assertEqual(self.reactor._prepare_tasks(["+c", "+"]), ["+", "c"])
 
         self.assertRaises(PyBuilderException, self.reactor._prepare_tasks, [])

--- a/src/unittest/python/test_utils.py
+++ b/src/unittest/python/test_utils.py
@@ -101,9 +101,9 @@ class PyBuilderTestCase(TestCase):
    but got: "{actual_line}"
 """.format(line_number=i, expected_line=expected_line, actual_line=actual_line)
 
-            self.assertEquals(expected_line, actual_line, message)
-        self.assertEquals(len(expected_lines), len(actual_lines),
-                          'Multi-line strings do not have the same number of lines')
+            self.assertEqual(expected_line, actual_line, message)
+        self.assertEqual(len(expected_lines), len(actual_lines),
+                         'Multi-line strings do not have the same number of lines')
 
 
 __all__ = [PyBuilderTestCase, Mock, MagicMock, patch, ANY, DEFAULT, call]

--- a/src/unittest/python/utils_tests.py
+++ b/src/unittest/python/utils_tests.py
@@ -73,9 +73,9 @@ class RenderReportTest(unittest.TestCase):
         actual_report = loads(actual_report_as_json_string)
         actual_keys = sorted(actual_report.keys())
 
-        self.assertEquals(actual_keys, ['eggs', 'spam'])
-        self.assertEquals(actual_report['eggs'], ["foo", "bar"])
-        self.assertEquals(actual_report['spam'], "baz")
+        self.assertEqual(actual_keys, ['eggs', 'spam'])
+        self.assertEqual(actual_report['eggs'], ["foo", "bar"])
+        self.assertEqual(actual_report['spam'], "baz")
 
 
 class FormatTimestampTest(unittest.TestCase):
@@ -93,37 +93,37 @@ class FormatTimestampTest(unittest.TestCase):
 
 class AsListTest(unittest.TestCase):
     def test_should_return_empty_list_when_no_argument_is_given(self):
-        self.assertEquals([], as_list())
+        self.assertEqual([], as_list())
 
     def test_should_return_empty_list_when_none_is_given(self):
-        self.assertEquals([], as_list(None))
+        self.assertEqual([], as_list(None))
 
     def test_should_wrap_single_string_as_list(self):
-        self.assertEquals(["spam"], as_list("spam"))
+        self.assertEqual(["spam"], as_list("spam"))
 
     def test_should_wrap_two_strings_as_list(self):
-        self.assertEquals(["spam", "eggs"], as_list("spam", "eggs"))
+        self.assertEqual(["spam", "eggs"], as_list("spam", "eggs"))
 
     def test_should_unwrap_single_list(self):
-        self.assertEquals(["spam", "eggs"], as_list(["spam", "eggs"]))
+        self.assertEqual(["spam", "eggs"], as_list(["spam", "eggs"]))
 
     def test_should_unwrap_multiple_lists(self):
-        self.assertEquals(
+        self.assertEqual(
             ["spam", "eggs", "foo", "bar"], as_list(["spam", "eggs"], ["foo", "bar"]))
 
     def test_should_unwrap_single_tuple(self):
-        self.assertEquals(["spam", "eggs"], as_list(("spam", "eggs")))
+        self.assertEqual(["spam", "eggs"], as_list(("spam", "eggs")))
 
     def test_should_unwrap_multiple_tuples(self):
-        self.assertEquals(
+        self.assertEqual(
             ["spam", "eggs", "foo", "bar"], as_list(("spam", "eggs"), ("foo", "bar")))
 
     def test_should_unwrap_mixed_tuples_and_lists_and_strings(self):
-        self.assertEquals(["spam", "eggs", "foo", "bar", "foobar"],
-                          as_list(("spam", "eggs"), ["foo", "bar"], "foobar"))
+        self.assertEqual(["spam", "eggs", "foo", "bar", "foobar"],
+                         as_list(("spam", "eggs"), ["foo", "bar"], "foobar"))
 
     def test_should_unwrap_mixed_tuples_and_lists_and_strings_and_ignore_none_values(self):
-        self.assertEquals(
+        self.assertEqual(
             ["spam", "eggs", "foo", "bar", "foobar"], as_list(None, ("spam", "eggs"),
                                                               None, ["foo", "bar"],
                                                               None, "foobar", None))
@@ -132,12 +132,12 @@ class AsListTest(unittest.TestCase):
         def foo():
             pass
 
-        self.assertEquals([foo], as_list(foo))
+        self.assertEqual([foo], as_list(foo))
 
 
 class TimedeltaInMillisTest(unittest.TestCase):
     def assertMillis(self, expected_millis, **timedelta_constructor_args):
-        self.assertEquals(expected_millis, timedelta_in_millis(
+        self.assertEqual(expected_millis, timedelta_in_millis(
             datetime.timedelta(**timedelta_constructor_args)))
 
     def test_should_return_number_of_millis_for_timedelta_with_microseconds_less_than_one_thousand(self):
@@ -166,26 +166,26 @@ class DiscoverFilesTest(unittest.TestCase):
     def test_should_only_return_py_suffix(self, walk):
         expected_result = ["spam/spam.py", "spam/eggs.py"]
         actual_result = set(discover_files("spam", ".py"))
-        self.assertEquals(set(expected_result), actual_result)
+        self.assertEqual(set(expected_result), actual_result)
         walk.assert_called_with("spam")
 
     @patch("pybuilder.utils.os.walk", return_value=[("spam", [], fake_dir_contents)])
     def test_should_only_return_py_glob(self, walk):
         expected_result = ["spam/README.md"]
         actual_result = set(discover_files_matching("spam", "README.?d"))
-        self.assertEquals(set(expected_result), actual_result)
+        self.assertEqual(set(expected_result), actual_result)
         walk.assert_called_with("spam")
 
 
 class DiscoverModulesTest(unittest.TestCase):
     @patch("pybuilder.utils.os.walk", return_value=[("spam", [], ["eggs.pi"])])
     def test_should_return_empty_list_when_directory_contains_single_file_not_matching_suffix(self, walk):
-        self.assertEquals([], discover_modules("spam", ".py"))
+        self.assertEqual([], discover_modules("spam", ".py"))
         walk.assert_called_with("spam")
 
     @patch("pybuilder.utils.os.walk", return_value=[("spam", [], ["eggs.py"])])
     def test_should_return_list_with_single_module_when_directory_contains_single_file(self, walk):
-        self.assertEquals(["eggs"], discover_modules("spam", ".py"))
+        self.assertEqual(["eggs"], discover_modules("spam", ".py"))
         walk.assert_called_with("spam")
 
     @patch("pybuilder.utils.os.walk", return_value=[("pet_shop", [],
@@ -194,28 +194,28 @@ class DiscoverModulesTest(unittest.TestCase):
     def test_should_only_match_py_files_regardless_of_glob(self, walk):
         expected_result = ["parrot"]
         actual_result = discover_modules_matching("pet_shop", "*parrot*")
-        self.assertEquals(set(expected_result), set(actual_result))
+        self.assertEqual(set(expected_result), set(actual_result))
         walk.assert_called_with("pet_shop")
 
     @patch("pybuilder.utils.os.walk", return_value=[("spam", [], ["eggs.py"])])
     def test_glob_should_return_list_with_single_module_when_directory_contains_single_file(self, walk):
-        self.assertEquals(["eggs"], discover_modules_matching("spam", "*"))
+        self.assertEqual(["eggs"], discover_modules_matching("spam", "*"))
         walk.assert_called_with("spam")
 
     @patch("pybuilder.utils.os.walk", return_value=[("spam", ["eggs"], []),
                                                     ("spam/eggs", [], ["__init__.py"])])
     def test_glob_should_return_list_with_single_module_when_directory_contains_package(self, walk):
-        self.assertEquals(["eggs"], discover_modules_matching("spam", "*"))
+        self.assertEqual(["eggs"], discover_modules_matching("spam", "*"))
 
         walk.assert_called_with("spam")
 
     @patch("pybuilder.utils.discover_files_matching", return_value=['/path/to/tests/reactor_tests.py'])
     def test_should_not_eat_first_character_of_modules_when_source_path_ends_with_slash(self, _):
-        self.assertEquals(["reactor_tests"], discover_modules_matching("/path/to/tests/", "*"))
+        self.assertEqual(["reactor_tests"], discover_modules_matching("/path/to/tests/", "*"))
 
     @patch("pybuilder.utils.discover_files_matching", return_value=['/path/to/tests/reactor_tests.py'])
     def test_should_honor_suffix_without_stripping_it_from_module_names(self, _):
-        self.assertEquals(["reactor_tests"], discover_modules_matching("/path/to/tests/", "*_tests"))
+        self.assertEqual(["reactor_tests"], discover_modules_matching("/path/to/tests/", "*_tests"))
 
 
 class GlobExpressionTest(unittest.TestCase):
@@ -253,8 +253,8 @@ class ApplyOnFilesTest(unittest.TestCase):
             relative_file_names.append(relative_file_name)
 
         apply_on_files("spam", callback, "*")
-        self.assertEquals(["spam/a", "spam/b", "spam/c"], absolute_file_names)
-        self.assertEquals(["a", "b", "c"], relative_file_names)
+        self.assertEqual(["spam/a", "spam/b", "spam/c"], absolute_file_names)
+        self.assertEqual(["a", "b", "c"], relative_file_names)
 
         walk.assert_called_with("spam")
 
@@ -266,7 +266,7 @@ class ApplyOnFilesTest(unittest.TestCase):
             called_on_file.append(absolute_file_name)
 
         apply_on_files("spam", callback, "a")
-        self.assertEquals(["spam/a"], called_on_file)
+        self.assertEqual(["spam/a"], called_on_file)
 
         walk.assert_called_with("spam")
 
@@ -275,11 +275,11 @@ class ApplyOnFilesTest(unittest.TestCase):
         called_on_file = []
 
         def callback(absolute_file_name, relative_file_name, additional_argument):
-            self.assertEquals("additional argument", additional_argument)
+            self.assertEqual("additional argument", additional_argument)
             called_on_file.append(absolute_file_name)
 
         apply_on_files("spam", callback, "a", "additional argument")
-        self.assertEquals(["spam/a"], called_on_file)
+        self.assertEqual(["spam/a"], called_on_file)
 
         walk.assert_called_with("spam")
 
@@ -331,23 +331,23 @@ class ForkTest(unittest.TestCase):
 
         val = fork_process(Mock(), target=test_func)
 
-        self.assertEquals(len(val), 2)
-        self.assertEquals(val[0], 0)
-        self.assertEquals(val[1], "success")
+        self.assertEqual(len(val), 2)
+        self.assertEqual(val[0], 0)
+        self.assertEqual(val[1], "success")
 
     def testForkParamPassing(self):
         def test_func(foo, bar):
             return "%s%s" % (foo, bar)
 
         val = fork_process(Mock(), target=test_func, kwargs={"foo": "foo", "bar": 10})
-        self.assertEquals(len(val), 2)
-        self.assertEquals(val[0], 0)
-        self.assertEquals(val[1], "foo10")
+        self.assertEqual(len(val), 2)
+        self.assertEqual(val[0], 0)
+        self.assertEqual(val[1], "foo10")
 
         val = fork_process(Mock(), target=test_func, args=("foo", 20))
-        self.assertEquals(len(val), 2)
-        self.assertEquals(val[0], 0)
-        self.assertEquals(val[1], "foo20")
+        self.assertEqual(len(val), 2)
+        self.assertEqual(val[0], 0)
+        self.assertEqual(val[1], "foo20")
 
     def testForkWithException(self):
         def test_func():
@@ -359,8 +359,8 @@ class ForkTest(unittest.TestCase):
             self.fail("should not have reached here, returned %s" % val)
         except Exception:
             ex_type, ex, tb = sys.exc_info()
-            self.assertEquals(ex_type, PyBuilderException)
-            self.assertEquals(ex.message, "Test failure message")
+            self.assertEqual(ex_type, PyBuilderException)
+            self.assertEqual(ex.message, "Test failure message")
             self.assertTrue(tb)
 
     def testForkWithValuePicklingError(self):
@@ -376,7 +376,7 @@ class ForkTest(unittest.TestCase):
             self.fail("should not have reached here")
         except Exception:
             ex_type, ex, tb = sys.exc_info()
-            self.assertEquals(ex_type, Exception)
+            self.assertEqual(ex_type, Exception)
             self.assertTrue(str(ex).startswith("Fatal error occurred in the forked process"))
             self.assertTrue("Can't pickle" in str(ex))
             self.assertTrue("FooError" in str(ex))
@@ -394,7 +394,7 @@ class ForkTest(unittest.TestCase):
             self.fail("should not have reached here, returned %s" % val)
         except Exception:
             ex_type, ex, tb = sys.exc_info()
-            self.assertEquals(ex_type, Exception)
+            self.assertEqual(ex_type, Exception)
             self.assertTrue(str(ex).startswith("Fatal error occurred in the forked process"))
             self.assertTrue("Can't pickle" in str(ex))
             self.assertTrue("FooError" in str(ex))
@@ -417,7 +417,7 @@ class ForkTest(unittest.TestCase):
             self.fail("should not have reached here, returned %s" % val)
         except Exception:
             ex_type, ex, tb = sys.exc_info()
-            self.assertEquals(ex_type, Exception)
+            self.assertEqual(ex_type, Exception)
             self.assertTrue(str(ex).startswith("Fatal error occurred in the forked process"))
             self.assertTrue("Can't pickle" in str(ex))
             self.assertTrue("FooError" in str(ex))
@@ -431,7 +431,7 @@ class CommandExecutionTest(unittest.TestCase):
     def test_execute_command(self, popen, _):
         popen.return_value = Mock()
         popen.return_value.wait.return_value = 0
-        self.assertEquals(execute_command(["test", "commands"]), 0)
-        self.assertEquals(execute_command(["test", "commands"], outfile_name="test.out"), 0)
-        self.assertEquals(
+        self.assertEqual(execute_command(["test", "commands"]), 0)
+        self.assertEqual(execute_command(["test", "commands"], outfile_name="test.out"), 0)
+        self.assertEqual(
             execute_command(["test", "commands"], outfile_name="test.out", error_file_name="test.out.err"), 0)

--- a/src/unittest/python/vcs_tests.py
+++ b/src/unittest/python/vcs_tests.py
@@ -18,14 +18,12 @@
 
 import unittest
 
-from test_utils import patch
-
 from pybuilder.errors import PyBuilderException
 from pybuilder.vcs import VCSRevision, count_travis
+from test_utils import patch
 
 
 class VCSRevisionTest(unittest.TestCase):
-
     def setUp(self):
         self.execute_command = patch("pybuilder.vcs.execute_command_and_capture_output").start()
 
@@ -50,31 +48,31 @@ class VCSRevisionTest(unittest.TestCase):
 
     def test_should_return_revision_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_without_modified_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451M", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_without_switched_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451S", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_without_sparse_partial_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451P", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_without_mixed_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451:321", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_without_trailing_emptiness_when_svnversion_succeeds(self):
         self.execute_command.return_value = 0, "451  \n", "any-stderr"
-        self.assertEquals("451", VCSRevision().get_svn_revision_count())
+        self.assertEqual("451", VCSRevision().get_svn_revision_count())
 
     def test_should_return_revision_when_git_revlist_succeeds(self):
         self.execute_command.return_value = 0, "1\n2\n3", "any-stderr"
-        self.assertEquals("3", VCSRevision().get_git_revision_count())
+        self.assertEqual("3", VCSRevision().get_git_revision_count())
 
     def test_should_detect_svn_when_status_succeeds(self):
         self.execute_command.return_value = 0, "", ""
@@ -99,13 +97,13 @@ class VCSRevisionTest(unittest.TestCase):
     def test_should_return_revision_when_git_from_count_succeeds(self):
         self.execute_command.side_effect = [(0, "", ""),  # is git
                                             (0, "1\n2\n3", "any-stderr")]
-        self.assertEquals("3", VCSRevision().count)
+        self.assertEqual("3", VCSRevision().count)
 
     def test_should_return_revision_when_svn_from_count_succeeds(self):
         self.execute_command.side_effect = [(1, "", ""),  # not git
                                             (0, "", ""),  # is svn
                                             (0, "451", "any-stderr")]
-        self.assertEquals("451", VCSRevision().count)
+        self.assertEqual("451", VCSRevision().count)
 
     def test_should_raise_when_not_git_or_svn(self):
         self.execute_command.side_effect = [(1, "", ""),  # not git
@@ -124,7 +122,7 @@ class VCSRevisionTest(unittest.TestCase):
     def test_should_return_revision_when_get_git_hash_succeeds(self):
         self.execute_command.side_effect = [(0, "", ""),  # is git
                                             (0, "451", "any-stderr")]
-        self.assertEquals("451", VCSRevision().get_git_hash())
+        self.assertEqual("451", VCSRevision().get_git_hash())
 
     def test_should_return_rev_and_travis_info_when_count_travis(self):
         environ_get = patch("pybuilder.vcs.os.environ.get").start()
@@ -135,4 +133,4 @@ class VCSRevisionTest(unittest.TestCase):
         travis = count_travis()
 
         if "123" not in travis or "456" not in travis:
-            self.assertEquals(False, True)
+            self.assertEqual(False, True)


### PR DESCRIPTION
Introduce `tail`
Harmozine printed errors

Rename assertEquals to assertEqual (remove deprecation warning)

fixes #535