### PR TITLE
Fix #554 and #546

### DIFF
--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -21,7 +21,7 @@ import re
 import sys
 
 from pybuilder.core import Dependency, RequirementsFile
-from pybuilder.utils import execute_command, as_list, execute_command_and_capture_output
+from pybuilder.utils import execute_command, as_list, execute_commandstr_and_capture_output
 # Plugin install_dependencies_plugin can reload pip_common and pip_utils. Do not use from ... import ...
 from pybuilder import pip_common
 
@@ -64,7 +64,7 @@ def pip_install_get_output(install_targets, index_url=None,
 
     if logger:
         logger.debug("Invoking pip: %s", command_line)
-    return execute_command_and_capture_output(*command_line, env=env, cwd=cwd)
+    return execute_commandstr_and_capture_output(command_line, env=env, cwd=cwd)
 
 
 def pip_install(install_targets, index_url=None, extra_index_url=None,

--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -21,7 +21,7 @@ import re
 import sys
 
 from pybuilder.core import Dependency, RequirementsFile
-from pybuilder.utils import execute_command, as_list
+from pybuilder.utils import execute_command, as_list, execute_command_and_capture_output
 # Plugin install_dependencies_plugin can reload pip_common and pip_utils. Do not use from ... import ...
 from pybuilder import pip_common
 
@@ -41,10 +41,69 @@ def build_dependency_version_string(mixed):
     return version
 
 
-def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=False, insecure_installs=None,
-                force_reinstall=False, target_dir=None, verbose=False, trusted_host=None, constraint_file=None,
+def pip_install_get_output(install_targets, index_url=None,
+                           extra_index_url=None, upgrade=False,
+                           insecure_installs=None,
+                           force_reinstall=False, target_dir=None,
+                           verbose=False, trusted_host=None,
+                           constraint_file=None, eager_upgrade=False,
+                           logger=None, env=None, cwd=None):
+    command_line = _create_pip_command_line(install_targets=install_targets,
+                                            index_url=index_url,
+                                            extra_index_url=extra_index_url,
+                                            upgrade=upgrade,
+                                            insecure_installs=insecure_installs,
+                                            force_reinstall=force_reinstall,
+                                            target_dir=target_dir,
+                                            verbose=verbose,
+                                            trusted_host=trusted_host,
+                                            constraint_file=constraint_file,
+                                            eager_upgrade=eager_upgrade)
+    if env is None:
+        env = os.environ
+
+    if logger:
+        logger.debug("Invoking pip: %s", command_line)
+    return execute_command_and_capture_output(*command_line, env=env, cwd=cwd)
+
+
+def pip_install(install_targets, index_url=None, extra_index_url=None,
+                upgrade=False, insecure_installs=None,
+                force_reinstall=False, target_dir=None,
+                verbose=False, trusted_host=None, constraint_file=None,
                 eager_upgrade=False,
-                logger=None, outfile_name=None, error_file_name=None, env=None, cwd=None):
+                logger=None, outfile_name=None,
+                error_file_name=None, env=None, cwd=None):
+
+    command_line = _create_pip_command_line(install_targets=install_targets,
+                                            index_url=index_url,
+                                            extra_index_url=extra_index_url,
+                                            upgrade=upgrade,
+                                            insecure_installs=insecure_installs,
+                                            force_reinstall=force_reinstall,
+                                            target_dir=target_dir,
+                                            verbose=verbose,
+                                            trusted_host=trusted_host,
+                                            constraint_file=constraint_file,
+                                            eager_upgrade=eager_upgrade)
+
+    if env is None:
+        env = os.environ
+
+    if logger:
+        logger.debug("Invoking pip: %s", command_line)
+
+    return execute_command(command_line, outfile_name=outfile_name,
+                           env=env, cwd=cwd,
+                           error_file_name=error_file_name, shell=False)
+
+
+def _create_pip_command_line(install_targets, index_url=None,
+                             extra_index_url=None, upgrade=False,
+                             insecure_installs=None,
+                             force_reinstall=False, target_dir=None,
+                             verbose=False, trusted_host=None,
+                             constraint_file=None, eager_upgrade=False):
     pip_command_line = list()
     pip_command_line.extend(PIP_EXEC_STANZA)
     pip_command_line.append("install")
@@ -61,14 +120,7 @@ def pip_install(install_targets, index_url=None, extra_index_url=None, upgrade=F
                                                       ))
     for install_target in as_list(install_targets):
         pip_command_line.extend(as_pip_install_target(install_target))
-
-    if env is None:
-        env = os.environ
-
-    if logger:
-        logger.debug("Invoking pip: %s", pip_command_line)
-    return execute_command(pip_command_line, outfile_name=outfile_name, env=env, cwd=cwd,
-                           error_file_name=error_file_name, shell=False)
+    return pip_command_line
 
 
 def build_pip_install_options(index_url=None, extra_index_url=None, upgrade=False, insecure_installs=None,

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -186,8 +186,8 @@ def execute_command(command_and_arguments, outfile_name=None, env=None, cwd=None
             out_file.close()
 
 
-def execute_command_and_capture_output(*command_and_arguments):
-    process_handle = Popen(command_and_arguments, stdout=PIPE, stderr=PIPE)
+def execute_command_and_capture_output(*command_and_arguments, env=None, cwd=None):
+    process_handle = Popen(command_and_arguments, stdout=PIPE, stderr=PIPE, env=env, cwd=cwd)
     stdout, stderr = process_handle.communicate()
     stdout, stderr = stdout.decode(sys.stdout.encoding or 'utf-8'), stderr.decode(sys.stderr.encoding or 'utf-8')
     process_return_code = process_handle.returncode

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -186,8 +186,8 @@ def execute_command(command_and_arguments, outfile_name=None, env=None, cwd=None
             out_file.close()
 
 
-def execute_command_and_capture_output(*command_and_arguments, env=None, cwd=None):
-    process_handle = Popen(command_and_arguments, stdout=PIPE, stderr=PIPE, env=env, cwd=cwd)
+def execute_command_and_capture_output(*command_and_arguments):
+    process_handle = Popen(command_and_arguments, stdout=PIPE, stderr=PIPE)
     stdout, stderr = process_handle.communicate()
     stdout, stderr = stdout.decode(sys.stdout.encoding or 'utf-8'), stderr.decode(sys.stderr.encoding or 'utf-8')
     process_return_code = process_handle.returncode

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -194,6 +194,14 @@ def execute_command_and_capture_output(*command_and_arguments, env=None, cwd=Non
     return process_return_code, stdout, stderr
 
 
+def execute_commandstr_and_capture_output(command_and_arguments, env=None, cwd=None):
+    process_handle = Popen(command_and_arguments, stdout=PIPE, stderr=PIPE, env=env, cwd=cwd)
+    stdout, stderr = process_handle.communicate()
+    stdout, stderr = stdout.decode(sys.stdout.encoding or 'utf-8'), stderr.decode(sys.stderr.encoding or 'utf-8')
+    process_return_code = process_handle.returncode
+    return process_return_code, stdout, stderr
+
+
 def tail(file_path, lines=20):
     import tailer
 

--- a/src/unittest/python/pluginloader_tests.py
+++ b/src/unittest/python/pluginloader_tests.py
@@ -224,7 +224,6 @@ class InstallExternalPluginTests(unittest.TestCase):
         execute.return_value = 0, "Ok", ""
 
         _install_external_plugin(Mock(), "pypi:some-plugin", "===1.2.3", Mock(), None)
-        new_pip_args = ["--upgrade", "--upgrade-strategy", "only-if-needed"]
         if(pip_version < "9.0"):
             execute.assert_called_with(
                 *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
@@ -233,7 +232,7 @@ class InstallExternalPluginTests(unittest.TestCase):
         else:
             execute.assert_called_with(
                 *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-                *new_pip_args,
+                "--upgrade", "--upgrade-strategy", "only-if-needed"
                 'some-plugin===1.2.3', cwd=".", env=ANY)
 
     @patch("pybuilder.pip_utils.execute_command_and_capture_output")

--- a/src/unittest/python/pluginloader_tests.py
+++ b/src/unittest/python/pluginloader_tests.py
@@ -210,59 +210,53 @@ class InstallExternalPluginTests(unittest.TestCase):
     def test_should_raise_error_when_protocol_is_invalid(self):
         self.assertRaises(MissingPluginException, _install_external_plugin, Mock(), "some-plugin", None, Mock(), None)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_install_plugin(self, execute):
         execute.return_value = 0, "Ok", ""
 
         _install_external_plugin(Mock(), "pypi:some-plugin", None, Mock(), None)
         execute.assert_called_with(
-            *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-            'some-plugin', cwd=".", env=ANY)
+            PIP_EXEC_STANZA + ['install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
+                               'some-plugin'], cwd=".", env=ANY)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_install_plugin_with_version(self, execute):
         execute.return_value = 0, "Ok", ""
 
         _install_external_plugin(Mock(), "pypi:some-plugin", "===1.2.3", Mock(), None)
-        if(pip_version < "9.0"):
-            execute.assert_called_with(
-                *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-                "--upgrade",
-                'some-plugin===1.2.3', cwd=".", env=ANY)
-        else:
-            execute.assert_called_with(
-                *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-                "--upgrade", "--upgrade-strategy", "only-if-needed"
-                'some-plugin===1.2.3', cwd=".", env=ANY)
+        execute.assert_called_with(
+                 PIP_EXEC_STANZA + ['install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY] +
+                 (["--upgrade"] if pip_version < "9.0" else ["--upgrade", "--upgrade-strategy", "only-if-needed"])
+                 + ['some-plugin===1.2.3'], cwd=".", env=ANY)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_install_plugin_with_vcs(self, execute):
         execute.return_value = 0, "Ok", ""
 
         _install_external_plugin(Mock(), "vcs:some-plugin URL", None, Mock(), None)
 
         execute.assert_called_with(
-            *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-            '--force-reinstall', 'some-plugin URL', cwd=".", env=ANY)
+            PIP_EXEC_STANZA + ['install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
+                               '--force-reinstall', 'some-plugin URL'], cwd=".", env=ANY)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_install_plugin_with_vcs_and_version(self, execute):
         execute.return_value = 0, "Ok", ""
 
         _install_external_plugin(Mock(), "vcs:some-plugin URL", "===1.2.3", Mock(), None)
 
         execute.assert_called_with(
-            *PIP_EXEC_STANZA, 'install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
-            '--force-reinstall', 'some-plugin URL',  cwd=".", env=ANY)
+            PIP_EXEC_STANZA + ['install', '--index-url', ANY, '--extra-index-url', ANY, '--trusted-host', ANY,
+                               '--force-reinstall', 'some-plugin URL'],  cwd=".", env=ANY)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_raise_error_when_install_from_pypi_fails(self, execute):
         execute.return_value = 1, "Not Ok", "Error"
 
         self.assertRaises(MissingPluginException, _install_external_plugin, Mock(), "pypi:some-plugin", None, Mock(),
                           None)
 
-    @patch("pybuilder.pip_utils.execute_command_and_capture_output")
+    @patch("pybuilder.pip_utils.execute_commandstr_and_capture_output")
     def test_should_raise_error_when_install_from_vcs_fails(self, execute):
         execute.return_value = 1, "Not Ok", "Error"
 


### PR DESCRIPTION
Remove the use of temporary file in install external plugin process. This prevent failures in windows, since it handles temp files differently from Unix based OS.

Basically the temporary file was used to read the output of pip install command. I've added a function in pip_utils to get the output of the install which internally use the already defined `execute_command_and_capture_output`. 