### PR TITLE
Please add config property "distutils_upload_repository_key" to select repo from .pypirc

### DIFF
--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -127,6 +127,7 @@ def initialize_distutils_plugin(project):
     project.set_property_if_unset("distutils_use_setuptools", True)
     project.set_property_if_unset("distutils_upload_register", False)
     project.set_property_if_unset("distutils_upload_repository", None)
+    project.set_property_if_unset("distutils_upload_repository_key", None)
     project.set_property_if_unset("distutils_upload_sign", False)
     project.set_property_if_unset("distutils_upload_sign_identity", None)
 
@@ -251,6 +252,10 @@ def upload(project, logger):
     repository_args = []
     if repository:
         repository_args = ["--repository-url", repository]
+    else:
+        repository_key = project.get_property("distutils_upload_repository_key")
+        if repository_key:
+            repository_args = ["--repository", repository_key]
 
     upload_sign = project.get_property("distutils_upload_sign")
     upload_sign_args = []

--- a/src/unittest/python/plugins/python/distutils_plugin_tests.py
+++ b/src/unittest/python/plugins/python/distutils_plugin_tests.py
@@ -760,6 +760,35 @@ class UploadTests(PyBuilderTestCase):
     @patch("pybuilder.plugins.python.distutils_plugin.open", create=True)
     @patch("pybuilder.plugins.python.distutils_plugin.os.walk")
     @patch("pybuilder.plugins.python.distutils_plugin._run_process_and_wait")
+    def test_upload_with_repo_and_repo_key(self, proc_runner, walk, *args):
+        proc_runner.return_value = 0
+        walk.return_value = [["dist", "", ["a", "b"]]]
+        self.project.set_property("distutils_upload_repository", "test repo")
+        self.project.set_property("distutils_upload_repository_key", "test repo key")
+
+        upload(self.project, MagicMock(Logger))
+        self.assertEqual(popen_distutils_args(self, 1, proc_runner),
+                         [["twine", "upload", "--repository-url", "test repo", nc("/whatever dist/dist/a"),
+                           nc("/whatever dist/dist/b")]])
+
+    @patch("pybuilder.plugins.python.distutils_plugin.os.mkdir")
+    @patch("pybuilder.plugins.python.distutils_plugin.open", create=True)
+    @patch("pybuilder.plugins.python.distutils_plugin.os.walk")
+    @patch("pybuilder.plugins.python.distutils_plugin._run_process_and_wait")
+    def test_upload_with_repo_key_only(self, proc_runner, walk, *args):
+        proc_runner.return_value = 0
+        walk.return_value = [["dist", "", ["a", "b"]]]
+        self.project.set_property("distutils_upload_repository_key", "test repo key")
+
+        upload(self.project, MagicMock(Logger))
+        self.assertEqual(popen_distutils_args(self, 1, proc_runner),
+                         [["twine", "upload", "--repository", "test repo key", nc("/whatever dist/dist/a"),
+                           nc("/whatever dist/dist/b")]])
+
+    @patch("pybuilder.plugins.python.distutils_plugin.os.mkdir")
+    @patch("pybuilder.plugins.python.distutils_plugin.open", create=True)
+    @patch("pybuilder.plugins.python.distutils_plugin.os.walk")
+    @patch("pybuilder.plugins.python.distutils_plugin._run_process_and_wait")
     def test_upload_with_signature(self, proc_runner, walk, *args):
         proc_runner.return_value = 0
         walk.return_value = [["dist", "", ["a", "b"]]]


### PR DESCRIPTION
We have a company internal pypi repository that requires authentication for upload.
Since I plan to upload .whls from a jenkins build, it won't be possible to enter username and password during the build process.

Twine allows to globally configure username/password via ~/.pypirc - that's why I added another config key to distutils_plugin.py, that results in twine's "--repository" option.

That simplifies my deploy scenario very much :)
So please integrate it in one of the next releases :)