### PR TITLE
Fix ignore hidden files in scripts

### DIFF
--- a/src/integrationtest/python/integrationtest_support.py
+++ b/src/integrationtest/python/integrationtest_support.py
@@ -54,6 +54,10 @@ class IntegrationTestSupport(unittest.TestCase):
         with open(self.full_path(name), "w") as file:
             file.writelines(content)
 
+    def write_binary_file(self, name, *content):
+        with open(self.full_path(name), "wb") as file:
+            file.writelines(content)
+
     def write_build_file(self, content):
         self.write_file("build.py", content)
 

--- a/src/integrationtest/python/should_ignore_hidden_files_in_scripts_tests.py
+++ b/src/integrationtest/python/should_ignore_hidden_files_in_scripts_tests.py
@@ -1,0 +1,49 @@
+#  This file is part of PyBuilder
+#
+#  Copyright 2018 The PyBuilder Team
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+from os.path import join
+
+from integrationtest_support import IntegrationTestSupport
+
+
+class Test (IntegrationTestSupport):
+
+    def test(self):
+        requirements = join(self.tmp_directory, "requirements.txt")
+        self.write_build_file("""
+from pybuilder.core import use_plugin
+
+use_plugin("python.core")
+use_plugin("python.distutils")
+
+name = "integration-test"
+default_task = "publish"
+
+""".format(requirements))
+        self.create_directory("src/main/python/spam")
+        self.write_file("src/main/python/spam/__init__.py", "")
+
+        self.create_directory("src/main/scripts")
+        # write the magic byte to the hidden file
+        self.write_binary_file("src/main/scripts/.eggs", b'\x8a')
+
+        reactor = self.prepare_reactor()
+        reactor.build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/pybuilder/plugins/python/core_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/core_plugin.py
@@ -67,7 +67,8 @@ def init_python_directories(project):
         if not os.path.exists(scripts_dir):
             return
         for script in os.listdir(scripts_dir):
-            if os.path.isfile(os.path.join(scripts_dir, script)):
+            if os.path.isfile(os.path.join(scripts_dir, script)) \
+               and not HIDDEN_FILE_NAME_PATTERN.match(script):
                 yield script
 
     project.list_scripts = list_scripts


### PR DESCRIPTION
Solves #608 and replaces #613 containing both tests for the issue and the fix for it.

The hard part was to determine that the byte `\x8a` is the magic byte that will crash `bdist_wheel`. 