### PR TITLE
Add option to allow pylint to break the build when it finds any warnings

### DIFF
--- a/src/unittest/python/plugins/python/pylint_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pylint_plugin_tests.py
@@ -25,6 +25,7 @@ from pybuilder.plugins.python.pylint_plugin import (check_pylint_availability,
                                                     init_pylint,
                                                     execute_pylint,
                                                     DEFAULT_PYLINT_OPTIONS)
+from pybuilder.errors import BuildFailedException
 
 
 class PylintPluginTests(TestCase):
@@ -57,3 +58,26 @@ class PylintPluginTests(TestCase):
         execute_pylint(project, Mock(Logger))
 
         execute_tool.assert_called_with(project, "pylint", ["pylint", "--test", "-f", "--x=y"], True)
+
+    def test_should_check_that_pylint_breaks_build(self):
+        project = Project(".")
+        init_pylint(project)
+
+        project.set_property('dir_source_main_python', 'src')
+        project.set_property("dir_reports", "target/reports")
+        project.set_property("pylint_options", ["--max-line-length=80"])
+        project.set_property("pylint_break_build", True)
+
+        with self.assertRaises(BuildFailedException):
+            execute_pylint(project, Mock(Logger))
+
+    def test_should_check_that_pylint_does_not_break_build(self):
+        project = Project(".")
+        init_pylint(project)
+
+        project.set_property('dir_source_main_python', 'src')
+        project.set_property("dir_reports", "target/reports")
+        project.set_property("pylint_options", ["--max-line-length=80"])
+        project.set_property("pylint_break_build", False)
+
+        execute_pylint(project, Mock(Logger))

--- a/src/unittest/python/plugins/python/pylint_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pylint_plugin_tests.py
@@ -64,10 +64,6 @@ class PylintPluginTests(TestCase):
     def test_should_break_build_when_warnings_and_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
-
-        project.set_property('dir_source_main_python', 'src')
-        project.set_property("dir_reports", "target/reports")
-        project.set_property("pylint_options", ["--max-line-length=80"])
         project.set_property("pylint_break_build", True)
 
         with self.assertRaises(BuildFailedException):
@@ -78,10 +74,6 @@ class PylintPluginTests(TestCase):
     def test_should_not_break_build_when_warnings_and_not_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
-
-        project.set_property('dir_source_main_python', 'src')
-        project.set_property("dir_reports", "target/reports")
-        project.set_property("pylint_options", ["--max-line-length=80"])
         project.set_property("pylint_break_build", False)
 
         execute_pylint(project, Mock(Logger))
@@ -91,10 +83,6 @@ class PylintPluginTests(TestCase):
     def test_should_not_break_build_when_no_warnings_and_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
-
-        project.set_property('dir_source_main_python', 'src')
-        project.set_property("dir_reports", "target/reports")
-        project.set_property("pylint_options", ["--max-line-length=80"])
         project.set_property("pylint_break_build", True)
 
         execute_pylint(project, Mock(Logger))
@@ -104,10 +92,6 @@ class PylintPluginTests(TestCase):
     def test_should_not_break_build_when_no_warnings_and_not_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
-
-        project.set_property('dir_source_main_python', 'src')
-        project.set_property("dir_reports", "target/reports")
-        project.set_property("pylint_options", ["--max-line-length=80"])
         project.set_property("pylint_break_build", False)
 
         execute_pylint(project, Mock(Logger))

--- a/src/unittest/python/plugins/python/pylint_plugin_tests.py
+++ b/src/unittest/python/plugins/python/pylint_plugin_tests.py
@@ -59,7 +59,9 @@ class PylintPluginTests(TestCase):
 
         execute_tool.assert_called_with(project, "pylint", ["pylint", "--test", "-f", "--x=y"], True)
 
-    def test_should_check_that_pylint_breaks_build(self):
+    @patch('pybuilder.plugins.python.pylint_plugin.read_file', return_value=['one warning', 'another warning'])
+    @patch('pybuilder.plugins.python.pylint_plugin.execute_tool_on_modules')
+    def test_should_break_build_when_warnings_and_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
 
@@ -71,7 +73,35 @@ class PylintPluginTests(TestCase):
         with self.assertRaises(BuildFailedException):
             execute_pylint(project, Mock(Logger))
 
-    def test_should_check_that_pylint_does_not_break_build(self):
+    @patch('pybuilder.plugins.python.pylint_plugin.read_file', return_value=['one warning', 'another warning'])
+    @patch('pybuilder.plugins.python.pylint_plugin.execute_tool_on_modules')
+    def test_should_not_break_build_when_warnings_and_not_set(self, execute_tool, warnings):
+        project = Project(".")
+        init_pylint(project)
+
+        project.set_property('dir_source_main_python', 'src')
+        project.set_property("dir_reports", "target/reports")
+        project.set_property("pylint_options", ["--max-line-length=80"])
+        project.set_property("pylint_break_build", False)
+
+        execute_pylint(project, Mock(Logger))
+
+    @patch('pybuilder.plugins.python.pylint_plugin.read_file', return_value=[])
+    @patch('pybuilder.plugins.python.pylint_plugin.execute_tool_on_modules')
+    def test_should_not_break_build_when_no_warnings_and_set(self, execute_tool, warnings):
+        project = Project(".")
+        init_pylint(project)
+
+        project.set_property('dir_source_main_python', 'src')
+        project.set_property("dir_reports", "target/reports")
+        project.set_property("pylint_options", ["--max-line-length=80"])
+        project.set_property("pylint_break_build", True)
+
+        execute_pylint(project, Mock(Logger))
+
+    @patch('pybuilder.plugins.python.pylint_plugin.read_file', return_value=[])
+    @patch('pybuilder.plugins.python.pylint_plugin.execute_tool_on_modules')
+    def test_should_not_break_build_when_no_warnings_and_not_set(self, execute_tool, warnings):
         project = Project(".")
         init_pylint(project)
 


### PR DESCRIPTION
This tries to behave exactly as the equivalent functionality from flake8.

The main reason for this is because https://github.com/AlexeySanko/pybuilder_pylint_extended is not compatible with the latest version of pylint. Also, see #629 .

It also makes more sense for the built-in plugin to be able to do this.