### PR TITLE
Fixed inability to override project name from command line

### DIFF
--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -307,7 +307,7 @@ class Project(object):
     """
 
     def __init__(self, basedir, version="1.0.dev0", name=None):
-        self.name = name
+        self._name = name
         self._version = None
         self._dist_version = None
         self.version = version
@@ -338,6 +338,14 @@ class Project(object):
         self._preinstall_script = None
         self._postinstall_script = None
 
+    @property
+    def name(self):
+        return self.get_property('name') or self._name
+    
+    @name.setter
+    def name(self, value):
+        self._name = value
+        
     def __str__(self):
         return "[Project name=%s basedir=%s]" % (self.name, self.basedir)
 

--- a/src/unittest/python/core_tests.py
+++ b/src/unittest/python/core_tests.py
@@ -128,6 +128,11 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(1, len(self.project.dependencies))
         self.assertEqual("spam", self.project.dependencies[0].name)
         self.assertEqual(">=0.7", self.project.dependencies[0].version)
+    
+    def test_property_overrides_should_be_able_to_override_name(self):
+        overridden_name = "newName"
+        self.project.set_property("name", overridden_name)
+        self.assertEqual(self.project.name, overridden_name)
 
 
 class ProjectManifestTests(unittest.TestCase):


### PR DESCRIPTION
https://github.com/pybuilder/pybuilder/issues/653


Created test to override name attribute in the project