### PR TITLE
Added dependency on xmlrunner.

### DIFF
--- a/src/main/python/pybuilder/plugins/python/unittest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/unittest_plugin.py
@@ -38,6 +38,7 @@ use_plugin("python.core")
 @init
 def init_test_source_directory(project):
     project.plugin_depends_on("unittest-xml-reporting", "~=2.5.2")
+    project.plugin_depends_on("xmlrunner")
     if PY2:
         project.plugin_depends_on("mock")
 


### PR DESCRIPTION
I just got this error while trying to build pybuilder:
```
[ERROR] Import error in test file c:\programdata\miniconda3\lib\site-packages\pybuilder\plugins\python\unittest_plugin.py, due to statement 'lambda stream: __import__("xmlrunner").XMLTestRunner(output
=project.expand_path("$dir_target/reports"),' on line 50
[ERROR] Error importing unittest: No module named 'xmlrunner'
```

So, adding the dependency in the plugin.