### PR TITLE
Fixing build stalls on OSX by using latest XCode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ branches:
     - master
     - doc/sphinxdoc
     - 0.11
+os:
+  - linux
+  - osx
+  - windows
+osx_image: xcode11.3
 env:
   jobs:
     - PYTHON_VERSION="3.8.2"
@@ -25,11 +30,8 @@ env:
     - PYB_ARGS: "'-E ci -v -X analyze install'"
     - TWINE_USERNAME: pybuilder-travis2
     - secure: D49QJr9Z4v9yz9VObFw0q44o2fy3YBjI48b6+Vb1qr2RNMF5GpVj+xWFTr9j1qMw7ilfwWCEKlHytKmh/OSOStUcd1vTlasGz8YefBCP8iIbvp9M6qcBKqMlp8f/6uxwUxak+OMvj5WuKwtyIUy8L9JwDxd02Q12MUW6SNtu2Lo=
-os:
-  - linux
-  - osx
-  - windows
 jobs:
+  fast_finish: true
   exclude:
     - os: windows
       env: PYTHON_VERSION="pypy2.7-7.3.0"
@@ -38,7 +40,8 @@ jobs:
     - os: windows
       env: PYTHON_VERSION="pypy3.6-7.3.0"
   allow_failures:
-    - if: env(PYTHON_VERSION) =~ /^pypy.+$/
+    - if: env(PYTHON_VERSION) =~ /^pypy.+$/ OR os = osx
+
 cache:
   directories:
     - $HOME/.pyenv

--- a/src/main/python/pybuilder/plugins/python/core_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/core_plugin.py
@@ -16,12 +16,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from os import sep, listdir, walk
-from os.path import isdir, isfile, exists, relpath
-
 import re
 import shutil
 from functools import partial
+from os import sep, listdir, walk
+from os.path import isdir, isfile, exists, relpath
 
 from pybuilder.core import description
 from pybuilder.core import task, use_plugin, init
@@ -102,26 +101,35 @@ def create_venvs(logger, project, reactor):
 
 def list_packages(project):
     source_path = project.expand_path("$" + PYTHON_SOURCES_PROPERTY)
+    result = []
     for root, dirs, files in walk(source_path):
         if "__init__.py" in files:
-            yield relpath(root, source_path).replace(sep, ".")
+            result.append(relpath(root, source_path).replace(sep, "."))
+
+    return sorted(result)
 
 
 def list_modules(project):
     source_path = project.expand_path("$" + PYTHON_SOURCES_PROPERTY)
+    result = []
     for potential_module_file in listdir(source_path):
         potential_module_path = np(jp(source_path, potential_module_file))
         if isfile(potential_module_path) and potential_module_file.endswith(".py"):
-            yield potential_module_file[:-len(".py")]
+            result.append(potential_module_file[:-3])
+
+    return sorted(result)
 
 
 def list_scripts(project):
     scripts_dir = project.expand_path("$" + SCRIPTS_SOURCES_PROPERTY)
+    result = []
     if not exists(scripts_dir):
-        return
+        return result
     for script in listdir(scripts_dir):
         if isfile(jp(scripts_dir, script)) and not HIDDEN_FILE_NAME_PATTERN.match(script):
-            yield np(script)
+            result.append(np(script))
+
+    return sorted(result)
 
 
 @task

--- a/src/unittest/python/plugins/python/core_plugin_tests.py
+++ b/src/unittest/python/plugins/python/core_plugin_tests.py
@@ -44,7 +44,7 @@ class InitPythonDirectoriesTest(unittest.TestCase):
         init_python_directories(self.project)
 
         self.assertEqual(
-            ["foo", "bar"],
+            ["bar", "foo"],
             self.greedy(self.project.list_modules())
         )
 


### PR DESCRIPTION
The sort order of the packages, modules and scripts must be stable across OSes