### PR TITLE
Fix `pybuilder` pyenv being appended instead of pre-pended to sys.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-PyBuilder
+[PyBuilder &#x2014; an easy-to-use build automation tool for Python](https://pybuilder.io)
 =========
-
-[PyBuilder](https://pybuilder.io)
-
 
 [![Gitter](https://img.shields.io/gitter/room/pybuilder/pybuilder?logo=gitter)](https://gitter.im/pybuilder/pybuilder)
 [![Build Status](https://img.shields.io/travis/pybuilder/pybuilder/master?logo=travis)](https://travis-ci.org/pybuilder/pybuilder)

--- a/build.py
+++ b/build.py
@@ -17,9 +17,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from os.path import dirname, join as jp, normcase as nc
-
 import sys
+from os.path import dirname, join as jp, normcase as nc
 
 # This is only necessary in PyBuilder sources for bootstrap
 build_sources = nc(jp(dirname(__file__), "src/main/python"))
@@ -75,12 +74,12 @@ allows the construction of build life-cycles similar to those known from other f
 Apache Maven and Gradle.
 """
 
-authors = [Author("Alexander Metzner", "alexander.metzner@gmail.com"),
+authors = [Author("Arcadiy Ivanov", "arcadiy@ivanov.biz"),
+           Author("Alexander Metzner", "alexander.metzner@gmail.com"),
            Author("Maximilien Riehl", "max@riehl.io"),
            Author("Michael Gruber", "aelgru@gmail.com"),
            Author("Udo Juettner", "udo.juettner@gmail.com"),
            Author("Marcel Wolf", "marcel.wolf@me.com"),
-           Author("Arcadiy Ivanov", "arcadiy@ivanov.biz"),
            Author("Valentin Haenel", "valentin@haenel.co"),
            ]
 url = "https://pybuilder.io"
@@ -128,7 +127,8 @@ def initialize(project):
 
     project.set_property("copy_resources_target", "$dir_dist/pybuilder")
     project.get_property("copy_resources_glob").append("LICENSE")
-    project.get_property("filter_resources_glob").append("**/pybuilder/__init__.py")
+    project.set_property("filter_resources_target", "$dir_dist")
+    project.get_property("filter_resources_glob").append("pybuilder/__init__.py")
     project.include_file("pybuilder", "LICENSE")
     project.include_file("pybuilder._vendor", "LICENSES")
     project.include_file("", "*.whl")  # All included binary wheels from vendors

--- a/src/main/python/pybuilder/plugins/python/remote_tools/unittest_tool.py
+++ b/src/main/python/pybuilder/plugins/python/remote_tools/unittest_tool.py
@@ -16,18 +16,23 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import sys
 from pybuilder.plugins.python.remote_tools import start_tool, RemoteObjectPipe, Tool, logger, PipeShutdownError
 
 __all__ = ["start_unittest_tool", "PipeShutdownError", logger]
 
 
 class UnitTestTool(Tool):
-    def __init__(self, test_modules, test_method_prefix):
+    def __init__(self, sys_paths, test_modules, test_method_prefix):
+        self.sys_paths = sys_paths
         self.test_modules = test_modules
         self.test_method_prefix = test_method_prefix
 
     def start(self, pipe):
         # type: (RemoteObjectPipe) -> None
+        for path in reversed(self.sys_paths):
+            sys.path.insert(0, path)
+
         import unittest
         loader = unittest.defaultTestLoader
         if self.test_method_prefix:
@@ -42,6 +47,6 @@ class UnitTestTool(Tool):
         pipe.hide("unittest_tests")
 
 
-def start_unittest_tool(pyenv, tools, test_modules, test_method_prefix, logging=0):
-    tool = UnitTestTool(test_modules, test_method_prefix)
+def start_unittest_tool(pyenv, tools, sys_paths, test_modules, test_method_prefix, logging=0):
+    tool = UnitTestTool(sys_paths, test_modules, test_method_prefix)
     return start_tool(pyenv, tools + [tool], name="unittest", logging=logging)

--- a/src/main/python/pybuilder/python_utils.py
+++ b/src/main/python/pybuilder/python_utils.py
@@ -287,6 +287,15 @@ def spawn_process(target=None, args=(), kwargs={}, group=None, name=None):
         raise_exception(ex, result.args[1])
 
 
+def prepend_env_to_path(python_env, sys_path):
+    """type: (PythonEnv, List(str)) -> None
+    Prepend venv directories to sys.path-like collection
+    """
+    for path in reversed(python_env.site_paths):
+        if path not in sys_path:
+            sys_path.insert(0, path)
+
+
 def add_env_to_path(python_env, sys_path):
     """type: (PythonEnv, List(str)) -> None
     Adds venv directories to sys.path-like collection

--- a/src/main/python/pybuilder/reactor.py
+++ b/src/main/python/pybuilder/reactor.py
@@ -25,9 +25,8 @@
 import imp
 import os
 import os.path
-from collections import deque
-
 import sys
+from collections import deque
 
 from pybuilder.core import (TASK_ATTRIBUTE, DEPENDS_ATTRIBUTE, DEPENDENTS_ATTRIBUTE,
                             DESCRIPTION_ATTRIBUTE, AFTER_ATTRIBUTE,
@@ -40,7 +39,7 @@ from pybuilder.pluginloader import (BuiltinPluginLoader,
                                     DispatchingPluginLoader,
                                     DownloadingPluginLoader)
 from pybuilder.python_env import PythonEnvRegistry, PythonEnv
-from pybuilder.python_utils import IS_WIN, PY2, odict, patch_mp_pyb_env, add_env_to_path
+from pybuilder.python_utils import IS_WIN, PY2, odict, patch_mp_pyb_env, prepend_env_to_path
 from pybuilder.utils import (as_list,
                              get_dist_version_string,
                              basestring, np, jp)
@@ -511,7 +510,7 @@ class Reactor:
                                                                                        system_env.is_pypy),
                                                                                 offline=self.project.offline)
 
-        add_env_to_path(plugin_env, sys.path)
+        prepend_env_to_path(plugin_env, sys.path)
         patch_mp_pyb_env(plugin_env)
 
     def _setup_deferred_plugin_import(self):

--- a/src/main/scripts/pyb
+++ b/src/main/scripts/pyb
@@ -18,8 +18,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pybuilder.cli
 import sys
+
+import pybuilder.cli
 
 if __name__ == '__main__':
     sys.exit(pybuilder.cli.main(*sys.argv[1:]))

--- a/src/unittest/python/plugins/python/unittest_plugin_tests.py
+++ b/src/unittest/python/plugins/python/unittest_plugin_tests.py
@@ -22,12 +22,11 @@ from unittest import TestCase, TextTestRunner
 
 from pybuilder.core import Project
 from pybuilder.plugins.python.unittest_plugin import (execute_tests, execute_tests_matching,
-                                                      _register_test_and_source_path_and_return_test_dir,
                                                       _instrument_result,
                                                       _create_runner,
                                                       _get_make_result_method_name,
                                                       report_to_ci_server)
-from pybuilder.utils import np, jp
+from pybuilder.utils import np
 from test_utils import Mock, patch
 
 __author__ = "Michael Gruber"
@@ -38,25 +37,6 @@ class PythonPathTests(TestCase):
         self.project = Project(np("/path/to/project"))
         self.project.set_property("dir_source_unittest_python", "unittest")
         self.project.set_property("dir_source_main_python", "src")
-
-    def test_should_register_source_paths(self):
-        system_path = [np("some/python/path")]
-
-        _register_test_and_source_path_and_return_test_dir(self.project, system_path, "unittest")
-
-        self.assertTrue(np(jp(self.project.basedir, "unittest")) in system_path)
-        self.assertTrue(np(jp(self.project.basedir, "src")) in system_path)
-
-    def test_should_put_project_sources_before_other_sources(self):
-        system_path = [np("irrelevant/sources")]
-
-        _register_test_and_source_path_and_return_test_dir(self.project, system_path, "unittest")
-
-        test_sources_index_in_path = system_path.index(np(jp(self.project.basedir, "unittest")))
-        main_sources_index_in_path = system_path.index(np(jp(self.project.basedir, "src")))
-        irrelevant_sources_index_in_path = system_path.index(np("irrelevant/sources"))
-        self.assertTrue(test_sources_index_in_path < irrelevant_sources_index_in_path and
-                        main_sources_index_in_path < irrelevant_sources_index_in_path)
 
 
 class ExecuteTestsTests(TestCase):
@@ -72,7 +52,7 @@ class ExecuteTestsTests(TestCase):
         pipe = Mock()
         pipe.remote_close_cause.return_value = None
         tool.return_value = (Mock(), pipe)
-        execute_tests(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "_tests.py")
+        execute_tests(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "_tests.py", ["a", "b"])
 
         mock_discover_modules_matching.assert_called_with("/path/to/test/sources", "*_tests.py")
 
@@ -84,7 +64,7 @@ class ExecuteTestsTests(TestCase):
         pipe = Mock()
         pipe.remote_close_cause.return_value = None
         tool.return_value = (Mock(), pipe)
-        execute_tests_matching(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "*_tests.py")
+        execute_tests_matching(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "*_tests.py", ["a", "b"])
 
         mock_discover_modules_matching.assert_called_with("/path/to/test/sources", "*_tests.py")
 
@@ -100,7 +80,8 @@ class ExecuteTestsTests(TestCase):
         mock_unittest.defaultTestLoader.loadTestsFromNames.return_value = mock_tests
         runner.return_value.run.return_value = self.mock_result
 
-        actual, _ = execute_tests(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "_tests.py")
+        actual, _ = execute_tests(Mock(), [], runner, self.mock_logger, "/path/to/test/sources", "_tests.py",
+                                  ["a", "b"])
 
         self.assertEqual(self.mock_result, actual)
 

--- a/travis/travis_shim.py
+++ b/travis/travis_shim.py
@@ -55,15 +55,8 @@ if __name__ == "__main__":
         environ["PATH"] = venv_bin_dir + os.pathsep + environ["PATH"]
         cmd_args = [python_bin, build_py] + pyb_args
 
-        if (not is_production or environ["PYTHON_VERSION"] in deploy_pythons
-                and environ["TRAVIS_OS_NAME"] in deploy_oses):
-            print("Will run PyBuilder build with the following args: %r" % cmd_args)
+        print("Will run PyBuilder build with the following args: %r" % cmd_args)
 
-            sys.stdout.flush()
+        sys.stdout.flush()
 
-            subprocess.check_call(cmd_args, env=environ)
-        else:
-            print("Skipping building on OS %r Python %r as "
-                  "this production version won't be deployed" % (environ["TRAVIS_OS_NAME"],
-                                                                 environ["PYTHON_VERSION"]))
-            sys.stdout.flush()
+        subprocess.check_call(cmd_args, env=environ)


### PR DESCRIPTION
Remove sys.path manipulation from unittest plugin and move it into the
tool.
Update README.md.
filter plugin should only be touching $dir_dist.
Return all Travis production builds.

fixes #696