### PR TITLE
Return `_register_test_and_source_path_and_return_test_dir` to make PyTest plugin work

### DIFF
--- a/src/main/python/pybuilder/plugins/python/unittest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/unittest_plugin.py
@@ -233,6 +233,15 @@ def _instrument_result(logger, result):
     return result
 
 
+def _register_test_and_source_path_and_return_test_dir(project, system_path, execution_prefix):
+    """This function is deprecated and will be removed and should not be used by any new code"""
+    test_dir = project.expand_path("$dir_source_%s_python" % execution_prefix)
+    system_path.insert(0, test_dir)
+    system_path.insert(0, project.expand_path("$dir_source_main_python"))
+
+    return test_dir
+
+
 def write_report(name, project, logger, result, console_out):
     project.write_report("%s" % name, console_out)
 


### PR DESCRIPTION
fixes #704, fixes #706, fixes AlexeySanko/pybuilder_pytest#19