### PR TITLE
Fixed pybuilder.execution.ExecutionManager.register_late_task_dependencies

### DIFF
--- a/src/main/python/pybuilder/execution.py
+++ b/src/main/python/pybuilder/execution.py
@@ -289,7 +289,7 @@ class ExecutionManager(object):
 
         for name in list(self._dependencies_pending_tasks.keys()):
             if self.has_task(name):
-                self.logger.debug("Resolved late dependency of task '%s' on %s", name, dependencies[name])
+                self.logger.debug("Resolved late dependency of task '%s' on %s", name, self._dependencies_pending_tasks[name])
                 self.get_task(name).dependencies.extend(self._dependencies_pending_tasks[name])
                 del self._dependencies_pending_tasks[name]
 


### PR DESCRIPTION
The fix for the issue - https://github.com/pybuilder/pybuilder/issues/737