### PR TITLE
Introduce `--no-venvs` option

### DIFF
--- a/src/cmdlinetest/test_help.t
+++ b/src/cmdlinetest/test_help.t
@@ -51,6 +51,7 @@ Usage:
                           Exclude any task dependencies (dangerous, may break
                           the build in unexpected ways)
       --reset-plugins     Reset plugins directory prior to running the build
+      --no-venvs          Disables the use of Python Virtual Environments
   
     Output Options:
       Modifies the messages printed during a build.

--- a/src/integrationtest/python/smoke_analyze_tests.py
+++ b/src/integrationtest/python/smoke_analyze_tests.py
@@ -3,7 +3,7 @@ import unittest
 from smoke_itest_support import SmokeIntegrationTestSupport
 
 
-class CleanSmokeTest(SmokeIntegrationTestSupport):
+class AnalyzeSmokeTest(SmokeIntegrationTestSupport):
     def test_smoke_analyze_publish_no_integration_no_coverage(self):
         self.smoke_test("-v", "-X", "analyze", "publish",
                         "--force-exclude", "run_integration_tests",

--- a/src/integrationtest/python/smoke_install_dependencies_no_venvs_tests.py
+++ b/src/integrationtest/python/smoke_install_dependencies_no_venvs_tests.py
@@ -18,16 +18,13 @@
 
 import unittest
 
-from pybuilder.python_utils import PY2, IS_WIN
 from smoke_itest_support import SmokeIntegrationTestSupport
 
 
-class SphinxWithApiSmokeTest(SmokeIntegrationTestSupport):
-    def test_smoke_sphinx_pyb_quickstart_with_api_doc(self):
-        self.smoke_test("-v", "-X", "-P", "sphinx_run_apidoc=True", "sphinx_pyb_quickstart",
-                        "sphinx_generate_documentation")
+class InstallDependenciesNoVenvsSmokeTest(SmokeIntegrationTestSupport):
+    def test_clean(self):
+        self.smoke_test("-v", "-X", "--no-venvs", "install_dependencies")
 
 
 if __name__ == "__main__":
-    if not (IS_WIN and PY2):
-        unittest.main()
+    unittest.main()

--- a/src/integrationtest/python/smoke_install_dependencies_tests.py
+++ b/src/integrationtest/python/smoke_install_dependencies_tests.py
@@ -21,7 +21,7 @@ import unittest
 from smoke_itest_support import SmokeIntegrationTestSupport
 
 
-class CleanSmokeTest(SmokeIntegrationTestSupport):
+class InstallDependenciesSmokeTest(SmokeIntegrationTestSupport):
     def test_clean(self):
         self.smoke_test("-v", "-X", "install_dependencies")
 

--- a/src/integrationtest/python/smoke_sphinx_quickstart_tests.py
+++ b/src/integrationtest/python/smoke_sphinx_quickstart_tests.py
@@ -22,7 +22,7 @@ from pybuilder.python_utils import PY2, IS_WIN
 from smoke_itest_support import SmokeIntegrationTestSupport
 
 
-class SphinxSmokeTest(SmokeIntegrationTestSupport):
+class SphinxQuickstartSmokeTest(SmokeIntegrationTestSupport):
     def test_smoke_sphinx_quickstart(self):
         self.smoke_test("-v", "-X", "sphinx_quickstart", "sphinx_generate_documentation")
 

--- a/src/integrationtest/python/smoke_vendorize_tests.py
+++ b/src/integrationtest/python/smoke_vendorize_tests.py
@@ -21,7 +21,7 @@ import unittest
 from smoke_itest_support import SmokeIntegrationTestSupport
 
 
-class SphinxSmokeTest(SmokeIntegrationTestSupport):
+class VendorizeSmokeTest(SmokeIntegrationTestSupport):
     PROJECT_FILES = list(SmokeIntegrationTestSupport.PROJECT_FILES) + ["docs"]
 
     def test_smoke_analyze_publish_no_integration_no_coverage(self):

--- a/src/main/python/pybuilder/cli.py
+++ b/src/main/python/pybuilder/cli.py
@@ -168,6 +168,12 @@ def parse_options(args):
                              default=False,
                              help="Reset plugins directory prior to running the build")
 
+    project_group.add_option("--no-venvs",
+                             action="store_true",
+                             dest="no_venvs",
+                             default=False,
+                             help="Disables the use of Python Virtual Environments")
+
     parser.add_option_group(project_group)
 
     output_group = optparse.OptionGroup(
@@ -427,7 +433,8 @@ def main(*args):
                                   exclude_optional_tasks=options.exclude_optional_tasks,
                                   exclude_tasks=options.exclude_tasks,
                                   exclude_all_optional=options.exclude_all_optional,
-                                  offline=options.offline
+                                  offline=options.offline,
+                                  no_venvs=options.no_venvs
                                   )
             if options.list_tasks:
                 print_list_of_tasks(reactor, quiet=options.very_quiet)
@@ -457,7 +464,8 @@ def main(*args):
                                   exclude_tasks=options.exclude_tasks,
                                   exclude_all_optional=options.exclude_all_optional,
                                   reset_plugins=options.reset_plugins,
-                                  offline=options.offline
+                                  offline=options.offline,
+                                  no_venvs=options.no_venvs
                                   )
 
             if options.verbose or options.debug:

--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -421,11 +421,12 @@ class Project(object):
     as well as some convenience methods to access these properties.
     """
 
-    def __init__(self, basedir, version="1.0.dev0", name=None, offline=False):
+    def __init__(self, basedir, version="1.0.dev0", name=None, offline=False, no_venvs=False):
         self.name = name
         self._version = None
         self._dist_version = None
         self.offline = offline
+        self.no_venvs = no_venvs
         self.version = version
         self.basedir = ap(basedir)
         if not self.name:


### PR DESCRIPTION
Short-circuits all VEnv management logic defaulting to incorrect 0.11 behaviors
Also fix test names

fixes #746