### PR TITLE
Make the failure in loading unit test modules a graceful one

### DIFF
--- a/src/integrationtest/python/issue_770_tests.py
+++ b/src/integrationtest/python/issue_770_tests.py
@@ -1,0 +1,57 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2021 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+import unittest
+
+from itest_support import IntegrationTestSupport
+
+
+class Test(IntegrationTestSupport):
+    def test(self):
+        self.write_build_file("""
+from pybuilder.core import use_plugin, init
+
+use_plugin("python.unittest")
+
+default_task = ["verify"]
+
+@init
+def init (project):
+    project.set_property("remote_debug", 2)
+""")
+        self.create_directory("src/main/python")
+        self.create_directory("src/unittest/python")
+        self.write_file("src/unittest/python/issue_770_tests.py", r"""
+print("Hello")
+   print("World!")
+""")
+        reactor = self.prepare_reactor()
+        with self.assertRaises(IndentationError) as e:
+            reactor.build()
+
+        self.assertEqual(e.exception.lineno, 3)
+
+        # This doesn't work on PyPy 3.7
+        # self.assertEqual(e.exception.offset, 3)
+
+        self.assertEqual(e.exception.text, '   print("World!")\n')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/pybuilder/plugins/python/remote_tools/unittest_tool.py
+++ b/src/main/python/pybuilder/plugins/python/remote_tools/unittest_tool.py
@@ -17,6 +17,7 @@
 #   limitations under the License.
 
 import sys
+
 from pybuilder.plugins.python.remote_tools import start_tool, RemoteObjectPipe, Tool, logger, PipeShutdownError
 
 __all__ = ["start_unittest_tool", "PipeShutdownError", logger]
@@ -37,9 +38,17 @@ class UnitTestTool(Tool):
         loader = unittest.defaultTestLoader
         if self.test_method_prefix:
             loader.testMethodPrefix = self.test_method_prefix
-        tests = loader.loadTestsFromNames(self.test_modules)
 
-        pipe.expose("unittest_tests", tests)
+        try:
+            tests = loader.loadTestsFromNames(self.test_modules)
+            pipe.expose("unittest_tests", tests)
+        except SystemExit as e:
+            raise e
+        except KeyboardInterrupt as e:
+            raise e
+        except Exception as e:
+            pipe.expose("unittest_tests", e, error=True)
+
         pipe.register_remote_type(unittest.BaseTestSuite)
         pipe.register_remote_type(unittest.TestCase)
 


### PR DESCRIPTION
Introduce a new opcode to indicate an exposed remote failure.
Ensure that failure is detected and handled appropriately in the unittest tool.

fixes #770