### PR TITLE
Revert to 0.12 behavior for integration test venv reuse

### DIFF
--- a/build.py
+++ b/build.py
@@ -153,6 +153,7 @@ def initialize(project):
     # PyPy distutils needs os.environ['PATH'] not matter what
     # Also Windows needs PATH for DLL loading in all Pythons
     project.set_property("integrationtest_inherit_environment", True)
+    project.set_property("integrationtest_python_env_recreate", True)
 
     project.set_property("distutils_readme_description", True)
     project.set_property("distutils_description_overwrite", True)

--- a/src/integrationtest/python/issue_813_tests.py
+++ b/src/integrationtest/python/issue_813_tests.py
@@ -1,0 +1,76 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2021 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import sys
+import textwrap
+import unittest
+
+from itest_support import IntegrationTestSupport
+
+
+class Issue807Test(IntegrationTestSupport):
+    def test(self):
+        if sys.version_info[:2] < (3, 8):
+            # importlib.metadata does not exist before Python 3.8
+            return
+
+        self.write_build_file("""
+from pybuilder.core import use_plugin, init
+
+use_plugin("python.core")
+use_plugin("python.integrationtest")
+
+@init
+def init (project):
+    project.set_property("verbose", True)
+
+    # Required to succeed on Windows
+    project.set_property("integrationtest_inherit_environment", True)
+        """)
+
+        self.create_directory("src/main/python")
+        self.create_directory("src/integrationtest/python")
+        self.write_file("src/main/python/code.py", textwrap.dedent(
+            """
+            def run_code():
+                pass
+            """))
+        self.write_file("src/integrationtest/python/code1_tests.py", textwrap.dedent(
+            """
+            import unittest
+            import code
+
+            class Code1Tests(unittest.TestCase):
+                def test_code1(self):
+                    code.run_code()
+            """))
+        self.write_file("src/integrationtest/python/code2_tests.py", textwrap.dedent(
+            """
+            import unittest
+            import code
+
+            class Code2Tests(unittest.TestCase):
+                def test_code2(self):
+                    code.run_code()
+            """))
+        reactor = self.prepare_reactor()
+        reactor.build("verify")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/pybuilder/plugins/python/core_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/core_plugin.py
@@ -90,7 +90,7 @@ def create_venvs(logger, project, reactor):
             per[venv_name] = system_env
 
 
-def create_venv(project, logger, reactor, venv_name, clear):
+def create_venv(project, logger, reactor, venv_name, clear, recreate_if_exists=False):
     if project.no_venvs:
         return
 
@@ -102,6 +102,9 @@ def create_venv(project, logger, reactor, venv_name, clear):
 
     try:
         current_env = per[venv_name]
+        if not recreate_if_exists:
+            logger.info("Reusing target '%s' VEnv in '%s'", venv_name, venv_dir)
+            return
         logger.info("Recreating target '%s' VEnv in '%s'%s", venv_name, venv_dir, " (refreshing)" if clear else "")
         venv_func = current_env.recreate_venv
     except KeyError:

--- a/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
@@ -44,6 +44,7 @@ def initialize_integrationtest_plugin(project):
     project.set_property_if_unset("integrationtest_always_verbose", False)
     project.set_property_if_unset("integrationtest_cpu_scaling_factor", 4)
     project.set_property_if_unset("integrationtest_python_env", "test")
+    project.set_property_if_unset("integrationtest_python_env_recreate", False)
 
     project.set_property_if_unset("integrationtest_file_suffix", None)  # deprecated, use integrationtest_file_glob.
 
@@ -223,7 +224,8 @@ def run_single_test(logger, project, reactor, reports_dir, test, output_test_nam
 
     venv_name = project.get_property("integrationtest_python_env")
     python_env = reactor.python_env_registry[venv_name]
-    create_venv(project, logger, reactor, venv_name, True)
+    create_venv(project, logger, reactor, venv_name, True,
+                recreate_if_exists=project.get_property("integrationtest_python_env_recreate"))
     env = prepare_environment(project)
     command_and_arguments = python_env.executable + [test]
     command_and_arguments += additional_integrationtest_commandline


### PR DESCRIPTION
Introduce the flag integrationtest_python_env_recreate (default to `False`) to
allow the user to control whether each integration test runs in a fresh
venv.

fixes #813