### PR TITLE
1. 3.11+ requires mp.spawn.set_executable to be used

### DIFF
--- a/src/integrationtest/python/base_itest_support.py
+++ b/src/integrationtest/python/base_itest_support.py
@@ -25,6 +25,11 @@ import unittest
 from io import StringIO
 from uuid import uuid4
 
+try:
+    from unittest.case import _addError
+except ImportError:
+    _addError = None
+
 
 class BaseIntegrationTestSupport(unittest.TestCase):
     def setUp(self):
@@ -122,10 +127,15 @@ class BaseIntegrationTestSupport(unittest.TestCase):
         result = self._get_result()
         return self._list2reason(result.errors), self._list2reason(result.failures)
 
-    def _get_result(self):
-        result = self.defaultTestResult()  # these 2 methods have no side effects
-        self._feedErrorsToResult(result, self._outcome.errors)
-        return result
+    if _addError:
+        def _get_result(self):
+            return self._outcome.result
+
+    else:
+        def _get_result(self):
+            result = self.defaultTestResult()  # these 2 methods have no side effects
+            self._feedErrorsToResult(result, self._outcome.errors)
+            return result
 
     def _list2reason(self, exc_list):
         if exc_list and exc_list[-1][0] is self:

--- a/src/main/python/pybuilder/remote/__init__.py
+++ b/src/main/python/pybuilder/remote/__init__.py
@@ -96,8 +96,8 @@ class Process:
         if tracker:
             tracker.getfd()
 
-        old_python_exe = patch_module._python_exe
-        patch_module._python_exe = pyenv.executable[0]  # pyenv's actual sys.executable
+        old_python_exe = patch_module.get_executable()
+        patch_module.set_executable(pyenv.executable[0])  # pyenv's actual sys.executable
 
         old_get_command_line = patch_module.get_command_line
 
@@ -135,7 +135,7 @@ class Process:
         try:
             return self.proc.start()
         finally:
-            patch_module._python_exe = old_python_exe
+            patch_module.set_executable(old_python_exe)
             patch_module.get_command_line = old_get_command_line
             patch_module.get_preparation_data = old_preparation_data
 


### PR DESCRIPTION
2. 3.11+ changed unittest.TestCase outcome/results internal API

fixes #856