### PR TITLE
Add `eager_update` option to dependencies

### DIFF
--- a/.github/workflows/pybuilder.yml
+++ b/.github/workflows/pybuilder.yml
@@ -66,6 +66,12 @@ jobs:
           - os: macos-12
             python-version: '3.7'
             with-homebrew: 'true'
+          - os: macos-11
+            python-version: '3.8'
+            with-homebrew: 'true'
+          - os: macos-12
+            python-version: '3.8'
+            with-homebrew: 'true'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -273,7 +273,7 @@ class Dependency(object):
     method from class Project to add a dependency to a project.
     """
 
-    def __init__(self, name, version=None, url=None, declaration_only=False):
+    def __init__(self, name, version=None, url=None, declaration_only=False, eager_update=None):
         from pybuilder import pip_common
         if version:
             try:
@@ -297,6 +297,7 @@ class Dependency(object):
         self.version = version
         self.url = url
         self.declaration_only = declaration_only
+        self.eager_update = eager_update
 
     def __eq__(self, other):
         if not isinstance(other, Dependency):
@@ -559,11 +560,11 @@ class Project(object):
     def plugin_dependencies(self):
         return list(sorted(self._plugin_dependencies))
 
-    def depends_on(self, name, version=None, url=None, declaration_only=False):
-        self._install_dependencies.add(Dependency(name, version, url, declaration_only))
+    def depends_on(self, name, version=None, url=None, declaration_only=False, eager_update=None):
+        self._install_dependencies.add(Dependency(name, version, url, declaration_only, eager_update=eager_update))
 
-    def build_depends_on(self, name, version=None, url=None, declaration_only=False):
-        self._build_dependencies.add(Dependency(name, version, url, declaration_only))
+    def build_depends_on(self, name, version=None, url=None, declaration_only=False, eager_update=None):
+        self._build_dependencies.add(Dependency(name, version, url, declaration_only, eager_update=eager_update))
 
     def depends_on_requirements(self, file, declaration_only=False):
         self._install_dependencies.add(RequirementsFile(file, declaration_only=declaration_only))
@@ -571,8 +572,8 @@ class Project(object):
     def build_depends_on_requirements(self, file):
         self._build_dependencies.add(RequirementsFile(file))
 
-    def plugin_depends_on(self, name, version=None, url=None, declaration_only=False):
-        self._plugin_dependencies.add(Dependency(name, version, url, declaration_only))
+    def plugin_depends_on(self, name, version=None, url=None, declaration_only=False, eager_update=None):
+        self._plugin_dependencies.add(Dependency(name, version, url, declaration_only, eager_update=eager_update))
 
     @property
     def environments(self):

--- a/src/main/python/pybuilder/install_utils.py
+++ b/src/main/python/pybuilder/install_utils.py
@@ -55,7 +55,10 @@ def install_dependencies(logger, project, dependencies, python_env,
         url = getattr(dependency, "url", None)
         install_options = {}
 
-        if should_update_package(dependency.version) and not getattr(dependency, "version_not_a_spec", False):
+        eager_update = getattr(dependency, "eager_update", None)
+        version_not_a_spec = getattr(dependency, "version_not_a_spec", False)
+        if eager_update or (eager_update is None and should_update_package(dependency.version) and
+                            not version_not_a_spec):
             install_options["upgrade"] = True
 
         if dependency.name in local_mapping or url:

--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -114,9 +114,9 @@ def as_str(value):
 @init
 def initialize_distutils_plugin(project):
     project.plugin_depends_on("pypandoc", "~=1.4")
-    project.plugin_depends_on("setuptools", ">=38.6.0")
     project.plugin_depends_on("twine", ">=1.15.0")
-    project.plugin_depends_on("wheel", ">=0.34.0")
+    project.plugin_depends_on("setuptools", ">=38.6.0", eager_update=False)
+    project.plugin_depends_on("wheel", ">=0.34.0", eager_update=False)
 
     project.set_property_if_unset("distutils_commands", ["sdist", "bdist_wheel"])
     project.set_property_if_unset("distutils_command_options", None)


### PR DESCRIPTION
Current functionality remains as is by default

`eager_update=True` forces dependency to always update on all installs

`eager_update=False` disables dependency updates even when version spec is non-exact