### PR TITLE
Add --project-info (-i) CLI option for JSON project configuration dump [release]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ pyb -v
 
 # Debug verbose output (includes all debug logging)
 pyb -vX
+
+# Dump project configuration as JSON (no build, runs initializers only)
+pyb -i
+# JSON goes to stdout, log messages go to stderr
+pyb -i 2>/dev/null | jq .project.name
+pyb -i -E ci -P verbose=true 2>/dev/null | jq .
 ```
 
 The build script (`build.py`) bootstraps by inserting `src/main/python` into
@@ -109,3 +115,55 @@ Release 0.13.19 [release]
 
 This is a fork. PRs go from `origin` (arcivanov) to `upstream` (pybuilder).
 Always pull from `upstream` before branching. Never push directly to `master`.
+
+## Documentation Updates (pybuilder.github.io)
+
+The project website is in the `pybuilder/pybuilder.github.io` GitHub repo
+(branch `source`). Changes to PyBuilder code must be accompanied by
+corresponding documentation updates.
+
+### For new features (new CLI flag, new plugin, new API):
+
+1. **Release notes** — add entry under the next version in
+   `articles/_release-notes/v0.13.x.md` (section `### New Features`)
+2. **Manual** — add or update the relevant section in `documentation/manual.md`
+3. **Tutorial** — if the feature is user-facing and discoverable, add a brief
+   section or example to `documentation/tutorial.md`
+4. **Coding agents** — update `documentation/coding-agents.md` (both the
+   "Quick Reference for Agents" section and the example CLAUDE.md) if the
+   feature affects how agents interact with builds (e.g. new CLI flags,
+   new build commands, new output formats)
+5. **Dedicated page** (optional) — for substantial features, create a new page
+   under `documentation/` and add it to `documentation/index.md`
+6. **Blog post** — create `articles/_posts/YYYY-MM-DD-slug.md` with front matter
+   `layout: post`, `author: arcivanov`, `categories: news`
+
+### For bug fixes:
+
+1. **Release notes** — add entry under `### Bugs Fixed` in
+   `articles/_release-notes/v0.13.x.md`
+2. **Manual/tutorial** — update only if the fix changes documented behavior or
+   corrects a misleading example
+
+### For parameter/property additions to existing plugins:
+
+1. **Release notes** — add entry under `### New Features` (if user-visible) or
+   `### Bugs Fixed` (if correcting behavior)
+2. **Plugin reference** — update property tables in `documentation/plugins.md`
+3. **Manual** — update if the property affects a workflow described there
+
+### For dependency upgrades and vendorized bumps:
+
+1. **Release notes** — add entry under `### Vendorized Dependency Upgrades`
+
+### File reference:
+
+| File | Purpose |
+|------|---------|
+| `articles/_release-notes/v0.13.x.md` | Release notes (add new version at top) |
+| `articles/_posts/YYYY-MM-DD-*.md` | Blog posts / announcements |
+| `documentation/manual.md` | Usage manual (CLI, properties, venvs, testing) |
+| `documentation/tutorial.md` | Getting started tutorial |
+| `documentation/plugins.md` | Plugin reference with property tables |
+| `documentation/coding-agents.md` | Agent instruction guidance and examples |
+| `documentation/index.md` | Documentation hub (add links for new pages) |

--- a/src/cmdlinetest/test_help.t
+++ b/src/cmdlinetest/test_help.t
@@ -27,6 +27,7 @@ Usage:
     -T, --list-plan-tasks
                           List tasks that will be run with current execution
                           plan
+    -i, --project-info    Output project configuration as JSON
     --start-project       Initialize build descriptors and Python project
                           structure
     --update-project      Update build descriptors and Python project structure

--- a/src/cmdlinetest/test_project_info.t
+++ b/src/cmdlinetest/test_project_info.t
@@ -1,0 +1,34 @@
+#   This file is part of PyBuilder
+#
+#   Copyright 2011-2020 PyBuilder Team
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+Find the project root (parent of target/dist):
+
+  $ PROJECT_ROOT="$(cd "$(dirname "$(which pyb)")/../../../.."; pwd)"
+
+Project info outputs valid JSON to stdout:
+
+  $ pyb -D "$PROJECT_ROOT" -i 2>/dev/null | python -c "import json, sys; d = json.load(sys.stdin); print(d['project']['name'])"
+  pybuilder
+
+Project info JSON contains expected top-level keys:
+
+  $ pyb -D "$PROJECT_ROOT" -i 2>/dev/null | python -c "import json, sys; d = json.load(sys.stdin); keys = sorted(d.keys()); print(' '.join(keys))"
+  dependencies environments files_to_install manifest_included_files package_data plugins project properties pybuilder_version tasks
+
+Project info is mutually exclusive with list-tasks:
+
+  $ pyb -i -t 2>&1 | head -1
+  Usage error: .* mutually exclusive.* (re)

--- a/src/main/python/pybuilder/cli.py
+++ b/src/main/python/pybuilder/cli.py
@@ -22,6 +22,7 @@
 """
 
 import datetime
+import json
 import optparse
 import re
 import sys
@@ -83,6 +84,21 @@ class ColoredStdOutLogger(StdOutLogger):
         return styled_text("[ERROR]", BOLD, fg(RED))
 
 
+class StdErrLogger(StdOutLogger):
+    def _do_log(self, level, message, *arguments):
+        formatted_message = self._format_message(message, *arguments)
+        log_level = self._level_to_string(level)
+        if self.log_time_format is not None:
+            timestamp = datetime.datetime.now().strftime(self.log_time_format) + ' '
+        else:
+            timestamp = ''
+        print_error_line("{0}{1} {2}".format(timestamp, log_level, formatted_message))
+
+
+class ColoredStdErrLogger(ColoredStdOutLogger, StdErrLogger):
+    pass
+
+
 def _log_time_format_argument__check_if_timestamp_passed(option, opt_str, value, parser):
     assert value is None
     value = DEFAULT_LOG_TIME_FORMAT
@@ -123,6 +139,12 @@ def parse_options(args):
                                                dest="list_plan_tasks",
                                                default=False,
                                                help="List tasks that will be run with current execution plan")
+
+    project_info_option = parser.add_option("-i", "--project-info",
+                                            action="store_true",
+                                            dest="project_info",
+                                            default=False,
+                                            help="Output project configuration as JSON")
 
     start_project_option = parser.add_option("--start-project",
                                              action="store_true",
@@ -252,6 +274,12 @@ def parse_options(args):
 
     if options.list_tasks and options.list_plan_tasks:
         parser.error("%s and %s are mutually exclusive" % (list_tasks_option, list_plan_tasks_option))
+    if options.project_info and (options.list_tasks or options.list_plan_tasks):
+        parser.error("%s is mutually exclusive with %s and %s" % (
+            project_info_option, list_tasks_option, list_plan_tasks_option))
+    if options.project_info and (options.start_project or options.update_project):
+        parser.error("%s is mutually exclusive with %s and %s" % (
+            project_info_option, start_project_option, update_project_option))
     if options.start_project and options.update_project:
         parser.error("%s and %s are mutually exclusive" % (start_project_option, update_project_option))
 
@@ -280,7 +308,7 @@ def should_colorize(options):
     return options.force_color or (sys.stdout.isatty() and not options.no_color)
 
 
-def init_logger(options):
+def init_logger(options, use_stderr=False):
     threshold = Logger.INFO
     if options.debug:
         threshold = Logger.DEBUG
@@ -288,12 +316,18 @@ def init_logger(options):
         threshold = Logger.WARN
 
     if not should_colorize(options):
-        logger = StdOutLogger(threshold, options.log_time_format)
+        if use_stderr:
+            logger = StdErrLogger(threshold, options.log_time_format)
+        else:
+            logger = StdOutLogger(threshold, options.log_time_format)
     else:
         if IS_WIN:
             import colorama
             colorama.init()
-        logger = ColoredStdOutLogger(threshold, options.log_time_format)
+        if use_stderr:
+            logger = ColoredStdErrLogger(threshold, options.log_time_format)
+        else:
+            logger = ColoredStdOutLogger(threshold, options.log_time_format)
 
     return logger
 
@@ -409,6 +443,115 @@ def print_plan_list_of_tasks(options, arguments, reactor, quiet=False):
     print_task_list(execution_plan, quiet)
 
 
+def _serialize_dependency(dep):
+    from pybuilder.core import RequirementsFile
+    if isinstance(dep, RequirementsFile):
+        return {
+            "name": dep.name,
+            "version": None,
+            "declaration_only": dep.declaration_only,
+            "type": "requirements_file"
+        }
+    return {
+        "name": dep.name,
+        "version": dep.version,
+        "url": dep.url,
+        "extras": dep.extras,
+        "markers": dep.markers,
+        "declaration_only": dep.declaration_only,
+        "type": "dependency"
+    }
+
+
+def _safe_property_value(value):
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_safe_property_value(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _safe_property_value(v) for k, v in value.items()}
+    if isinstance(value, set):
+        return sorted([_safe_property_value(v) for v in value], key=str)
+    return repr(value)
+
+
+def _build_project_info(reactor):
+    project = reactor.project
+
+    def serialize_person(p):
+        if isinstance(p, (dict, str)):
+            return p
+        result = {"name": p.name}
+        if p.email:
+            result["email"] = p.email
+        if p.roles:
+            result["roles"] = list(p.roles)
+        return result
+
+    def serialize_person_list(persons):
+        return [serialize_person(p) for p in persons]
+
+    tasks_info = []
+    for task in sorted(reactor.get_tasks()):
+        task_deps = []
+        for dep in task.dependencies:
+            task_deps.append({
+                "name": str(dep.name),
+                "optional": dep.optional
+            })
+        tasks_info.append({
+            "name": task.name,
+            "description": task_description(task),
+            "dependencies": task_deps
+        })
+
+    return {
+        "pybuilder_version": __version__,
+        "project": {
+            "name": project.name,
+            "version": project.version,
+            "dist_version": project.dist_version,
+            "basedir": project.basedir,
+            "summary": project.summary,
+            "description": project.description,
+            "author": project.author,
+            "authors": serialize_person_list(project.authors),
+            "maintainer": project.maintainer,
+            "maintainers": serialize_person_list(project.maintainers),
+            "license": project.license,
+            "url": project.url,
+            "urls": project.urls,
+            "requires_python": project.requires_python,
+            "default_task": project.default_task,
+            "obsoletes": project.obsoletes,
+            "explicit_namespaces": project.explicit_namespaces,
+        },
+        "environments": list(project.environments),
+        "properties": {str(k): _safe_property_value(v) for k, v in sorted(project.properties.items())},
+        "plugins": list(reactor.get_plugins()),
+        "dependencies": {
+            "runtime": [_serialize_dependency(d) for d in project.dependencies],
+            "build": [_serialize_dependency(d) for d in project.build_dependencies],
+            "plugin": [_serialize_dependency(d) for d in project.plugin_dependencies],
+            "extras": {name: [_serialize_dependency(d) for d in deps]
+                       for name, deps in project.extras_dependencies.items()}
+        },
+        "tasks": tasks_info,
+        "manifest_included_files": project.manifest_included_files,
+        "package_data": dict(project.package_data),
+        "files_to_install": [[dest, files] for dest, files in project.files_to_install],
+    }
+
+
+def print_project_info(reactor, environments):
+    reactor.project._environments = tuple(environments)
+    reactor.execution_manager.execute_initializers(
+        environments, logger=reactor.logger, project=reactor.project, reactor=reactor)
+
+    info = _build_project_info(reactor)
+    print_text_line(json.dumps(info, indent=2, default=str))
+
+
 def get_failure_message():
     exc_type, exc_obj, exc_tb = sys.exc_info()
 
@@ -448,7 +591,7 @@ def main(*args):
 
     start = datetime.datetime.now()
 
-    logger = init_logger(options)
+    logger = init_logger(options, use_stderr=options.project_info)
     reactor = init_reactor(logger)
 
     if options.start_project:
@@ -456,6 +599,22 @@ def main(*args):
 
     if options.update_project:
         return update_project()
+
+    if options.project_info:
+        try:
+            reactor.prepare_build(property_overrides=options.property_overrides,
+                                  project_directory=options.project_directory,
+                                  exclude_optional_tasks=options.exclude_optional_tasks,
+                                  exclude_tasks=options.exclude_tasks,
+                                  exclude_all_optional=options.exclude_all_optional,
+                                  offline=options.offline,
+                                  no_venvs=options.no_venvs
+                                  )
+            print_project_info(reactor, options.environments)
+            return 0
+        except PyBuilderException:
+            print_build_status(get_failure_message(), options, successful=False)
+            return 1
 
     if options.list_tasks or options.list_plan_tasks:
         try:

--- a/src/unittest/python/cli_tests.py
+++ b/src/unittest/python/cli_tests.py
@@ -16,17 +16,25 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import json
+import sys
 import unittest
 
 from pybuilder.cli import (parse_options,
                            ColoredStdOutLogger,
+                           StdErrLogger,
+                           ColoredStdErrLogger,
                            CommandLineUsageException,
                            StdOutLogger,
                            length_of_longest_string,
                            print_list_of_tasks,
+                           print_project_info,
+                           _build_project_info,
+                           _safe_property_value,
+                           _serialize_dependency,
                            DEFAULT_LOG_TIME_FORMAT,
                            get_failure_message)
-from pybuilder.core import Logger
+from pybuilder.core import Logger, Dependency, RequirementsFile
 from pybuilder.errors import PyBuilderException
 from test_utils import Mock, patch, call
 
@@ -178,6 +186,8 @@ class ParseOptionsTest(unittest.TestCase):
                          overrides.get("quiet", False))
         self.assertEqual(options.list_tasks,
                          overrides.get("list_tasks", False))
+        self.assertEqual(options.project_info,
+                         overrides.get("project_info", False))
         self.assertEqual(options.no_color,
                          overrides.get("no_color", False))
         self.assertEqual(options.property_overrides,
@@ -315,3 +325,313 @@ class ErrorHandlingTests(unittest.TestCase):
             raise PyBuilderException("test")
         except Exception:
             self.assertRegex(get_failure_message(), r"test \(cli_tests.py\:\d+\)")
+
+
+class ProjectInfoOptionTests(unittest.TestCase):
+    def test_should_parse_project_info_short_flag(self):
+        options, arguments = parse_options(["-i"])
+        self.assertTrue(options.project_info)
+        self.assertEqual([], arguments)
+
+    def test_should_parse_project_info_long_flag(self):
+        options, arguments = parse_options(["--project-info"])
+        self.assertTrue(options.project_info)
+        self.assertEqual([], arguments)
+
+    def test_should_default_project_info_to_false(self):
+        options, arguments = parse_options([])
+        self.assertFalse(options.project_info)
+
+    def test_should_reject_project_info_with_list_tasks(self):
+        self.assertRaises(CommandLineUsageException, parse_options, ["-i", "-t"])
+
+    def test_should_reject_project_info_with_list_plan_tasks(self):
+        self.assertRaises(CommandLineUsageException, parse_options, ["-i", "-T"])
+
+    def test_should_reject_project_info_with_start_project(self):
+        self.assertRaises(CommandLineUsageException, parse_options, ["-i", "--start-project"])
+
+    def test_should_reject_project_info_with_update_project(self):
+        self.assertRaises(CommandLineUsageException, parse_options, ["-i", "--update-project"])
+
+    def test_should_allow_project_info_with_environment(self):
+        options, _ = parse_options(["-i", "-E", "ci"])
+        self.assertTrue(options.project_info)
+        self.assertEqual(options.environments, ["ci"])
+
+    def test_should_allow_project_info_with_property_override(self):
+        options, _ = parse_options(["-i", "-P", "spam=eggs"])
+        self.assertTrue(options.project_info)
+        self.assertEqual(options.property_overrides, {"spam": "eggs"})
+
+    def test_should_allow_project_info_with_debug(self):
+        options, _ = parse_options(["-i", "-X"])
+        self.assertTrue(options.project_info)
+        self.assertTrue(options.debug)
+
+
+class StdErrLoggerTest(unittest.TestCase):
+    class StreamWrapper(object):
+        def __init__(self, wrapped):
+            self.text = ''
+            self.__wrapped = wrapped
+
+        def __getattr__(self, name):
+            return getattr(self.__wrapped, name)
+
+        def write(self, text):
+            self.text += text
+
+    def test_stderr_logger_should_write_to_stderr(self):
+        logger = StdErrLogger()
+        original = sys.stderr
+        try:
+            sys.stderr = self.StreamWrapper(sys.stderr)
+            logger.info("Test message")
+            self.assertIn("Test message", sys.stderr.text)
+        finally:
+            sys.stderr = original
+
+    def test_stderr_logger_should_not_write_to_stdout(self):
+        logger = StdErrLogger()
+        original_out = sys.stdout
+        original_err = sys.stderr
+        try:
+            sys.stdout = self.StreamWrapper(sys.stdout)
+            sys.stderr = self.StreamWrapper(sys.stderr)
+            logger.info("Test message")
+            self.assertEqual("", sys.stdout.text)
+            self.assertIn("Test message", sys.stderr.text)
+        finally:
+            sys.stdout = original_out
+            sys.stderr = original_err
+
+    def test_colored_stderr_logger_should_write_to_stderr(self):
+        logger = ColoredStdErrLogger()
+        original = sys.stderr
+        try:
+            sys.stderr = self.StreamWrapper(sys.stderr)
+            logger.info("Test message")
+            self.assertIn("Test message", sys.stderr.text)
+        finally:
+            sys.stderr = original
+
+
+class SafePropertyValueTests(unittest.TestCase):
+    def test_should_pass_through_none(self):
+        self.assertIsNone(_safe_property_value(None))
+
+    def test_should_pass_through_string(self):
+        self.assertEqual(_safe_property_value("hello"), "hello")
+
+    def test_should_pass_through_int(self):
+        self.assertEqual(_safe_property_value(42), 42)
+
+    def test_should_pass_through_float(self):
+        self.assertEqual(_safe_property_value(3.14), 3.14)
+
+    def test_should_pass_through_bool(self):
+        self.assertEqual(_safe_property_value(True), True)
+        self.assertEqual(_safe_property_value(False), False)
+
+    def test_should_convert_list(self):
+        self.assertEqual(_safe_property_value([1, "a", True]), [1, "a", True])
+
+    def test_should_convert_tuple(self):
+        self.assertEqual(_safe_property_value((1, "a")), [1, "a"])
+
+    def test_should_convert_nested_dict(self):
+        self.assertEqual(_safe_property_value({"k": [1, 2]}), {"k": [1, 2]})
+
+    def test_should_convert_set_to_sorted_list(self):
+        result = _safe_property_value({3, 1, 2})
+        self.assertEqual(result, [1, 2, 3])
+
+    def test_should_repr_non_serializable_objects(self):
+        class Custom:
+            def __repr__(self):
+                return "<custom>"
+        self.assertEqual(_safe_property_value(Custom()), "<custom>")
+
+
+class SerializeDependencyTests(unittest.TestCase):
+    def test_should_serialize_dependency_with_version(self):
+        dep = Dependency("requests", ">=2.28")
+        result = _serialize_dependency(dep)
+        self.assertEqual(result["name"], "requests")
+        self.assertEqual(result["type"], "dependency")
+        self.assertIn("version", result)
+        self.assertIn("url", result)
+        self.assertIn("extras", result)
+        self.assertIn("markers", result)
+        self.assertIn("declaration_only", result)
+
+    def test_should_serialize_dependency_without_version(self):
+        dep = Dependency("mock")
+        result = _serialize_dependency(dep)
+        self.assertEqual(result["name"], "mock")
+        self.assertIsNone(result["version"])
+
+    def test_should_serialize_requirements_file(self):
+        req = RequirementsFile("requirements.txt")
+        result = _serialize_dependency(req)
+        self.assertEqual(result["name"], "requirements.txt")
+        self.assertEqual(result["type"], "requirements_file")
+        self.assertIsNone(result["version"])
+        self.assertIn("declaration_only", result)
+
+
+@patch("pybuilder.cli.print_text_line", return_value=None)
+class ProjectInfoTests(unittest.TestCase):
+    def _create_mock_reactor(self):
+        def __eq__(self, other):
+            return False
+
+        def __ne__(self, other):
+            return not self.__eq__(other)
+
+        def __lt__(self, other):
+            return False
+
+        mock_reactor = Mock()
+        mock_reactor.project.name = "test-project"
+        mock_reactor.project.version = "1.0.0"
+        mock_reactor.project.dist_version = "1.0.0"
+        mock_reactor.project.basedir = "/test"
+        mock_reactor.project.summary = "Test summary"
+        mock_reactor.project.description = "Test description"
+        mock_reactor.project.author = "Test Author"
+        mock_reactor.project.authors = ["Author One", "Author Two"]
+        mock_reactor.project.maintainer = ""
+        mock_reactor.project.maintainers = []
+        mock_reactor.project.license = "Apache-2.0"
+        mock_reactor.project.url = "https://example.com"
+        mock_reactor.project.urls = {"Homepage": "https://example.com", "Source": "https://github.com/example"}
+        mock_reactor.project.requires_python = ">=3.10"
+        mock_reactor.project.default_task = "publish"
+        mock_reactor.project.obsoletes = []
+        mock_reactor.project.explicit_namespaces = []
+        mock_reactor.project.environments = ()
+        mock_reactor.project.properties = {"verbose": False, "basedir": "/test"}
+        mock_reactor.project.dependencies = []
+        mock_reactor.project.build_dependencies = []
+        mock_reactor.project.plugin_dependencies = []
+        mock_reactor.project.extras_dependencies = {}
+        mock_reactor.project.manifest_included_files = []
+        mock_reactor.project.package_data = {}
+        mock_reactor.project.files_to_install = []
+        mock_reactor.get_plugins.return_value = ["python.core", "python.unittest"]
+        task_1 = Mock()
+        task_1.__eq__ = __eq__
+        task_1.__ne__ = __ne__
+        task_1.__lt__ = __lt__
+        task_1.name = "clean"
+        task_1.description = ["Cleans", "the", "output"]
+        task_1.dependencies = []
+        task_2 = Mock()
+        task_2.__eq__ = __eq__
+        task_2.__ne__ = __ne__
+        task_2.__lt__ = __lt__
+        task_2.name = "publish"
+        task_2.description = ["Publishes", "the", "project"]
+        dep = Mock()
+        dep.name = "clean"
+        dep.optional = False
+        task_2.dependencies = [dep]
+        mock_reactor.get_tasks.return_value = [task_1, task_2]
+        return mock_reactor
+
+    def test_should_output_valid_json(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertEqual(info["project"]["name"], "test-project")
+        self.assertEqual(info["project"]["version"], "1.0.0")
+
+    def test_should_call_execute_initializers(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, ["ci"])
+
+        reactor.execution_manager.execute_initializers.assert_called_once()
+        call_kwargs = reactor.execution_manager.execute_initializers.call_args
+        self.assertEqual(call_kwargs[0][0], ["ci"])
+
+    def test_should_set_environments_on_project(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, ["ci", "production"])
+
+        self.assertEqual(reactor.project._environments, ("ci", "production"))
+
+    def test_should_include_plugins(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertEqual(info["plugins"], ["python.core", "python.unittest"])
+
+    def test_should_include_tasks(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertEqual(len(info["tasks"]), 2)
+        task_names = [t["name"] for t in info["tasks"]]
+        self.assertIn("clean", task_names)
+        self.assertIn("publish", task_names)
+
+    def test_should_include_task_dependencies(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        publish_task = [t for t in info["tasks"] if t["name"] == "publish"][0]
+        self.assertEqual(len(publish_task["dependencies"]), 1)
+        self.assertEqual(publish_task["dependencies"][0]["name"], "clean")
+        self.assertFalse(publish_task["dependencies"][0]["optional"])
+
+    def test_should_include_project_metadata(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertEqual(info["project"]["summary"], "Test summary")
+        self.assertEqual(info["project"]["license"], "Apache-2.0")
+        self.assertEqual(info["project"]["url"], "https://example.com")
+        self.assertEqual(info["project"]["requires_python"], ">=3.10")
+        self.assertEqual(info["project"]["default_task"], "publish")
+        self.assertEqual(info["project"]["authors"], ["Author One", "Author Two"])
+
+    def test_should_include_properties(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        reactor.project.properties = {"verbose": False, "basedir": "/test", "custom_prop": "custom_val"}
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertEqual(info["properties"]["custom_prop"], "custom_val")
+        self.assertEqual(info["properties"]["basedir"], "/test")
+
+    def test_should_include_pybuilder_version(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertIn("pybuilder_version", info)
+
+    def test_should_include_dependency_sections(self, print_text_line):
+        reactor = self._create_mock_reactor()
+        print_project_info(reactor, [])
+
+        output = print_text_line.call_args[0][0]
+        info = json.loads(output)
+        self.assertIn("runtime", info["dependencies"])
+        self.assertIn("build", info["dependencies"])
+        self.assertIn("plugin", info["dependencies"])
+        self.assertIn("extras", info["dependencies"])


### PR DESCRIPTION
## Summary

- Adds `pyb -i` / `pyb --project-info` that outputs the full project configuration as pretty-printed JSON to stdout without running a build
- Runs plugin initializers to populate all properties but does not execute any tasks or create build/test venvs
- Log messages go to stderr (via new `StdErrLogger` / `ColoredStdErrLogger` classes) so stdout is always clean, parseable JSON
- Mutually exclusive with `-t`, `-T`, `--start-project`, `--update-project`

### JSON output includes:
- Project metadata (name, version, authors, license, URLs, etc.)
- All build properties (built-in + plugin-defined, after initializers run)
- Loaded plugins
- Runtime, build, plugin, and extras dependencies
- Available tasks with descriptions and dependency graphs
- Manifest files, package data, files to install

### Usage:
```bash
pyb -i 2>/dev/null | jq .project.name
pyb -i -E ci -P verbose=true 2>/dev/null | jq .properties
```

## Test plan

- [x] 678 unit tests pass (including new tests for option parsing, stderr logging, serialization, JSON output)
- [x] 3 cram tests pass (help output updated, new project-info cram test, existing no-build test)
- [x] `pyb -i | python -m json.tool` produces valid JSON
- [x] `pyb -i -X 2>log.txt` sends debug logs to stderr, JSON to stdout
- [x] `pyb -i -t` rejected as mutually exclusive